### PR TITLE
Creating versions of interface that have to be called in a shard map context

### DIFF
--- a/docs/api/potrs.md
+++ b/docs/api/potrs.md
@@ -2,4 +2,4 @@
 
 ::: jaxmg._potrs.potrs
 
-::: jaxmg._potrs.potrs_no_shardmap
+::: jaxmg._potrs.potrs_shardmap_ctx

--- a/docs/api/syevd.md
+++ b/docs/api/syevd.md
@@ -1,3 +1,5 @@
 # jaxmg.syevd
 
 ::: jaxmg._syevd.syevd
+
+::: jaxmg._syevd.syevd_shardmap_ctx

--- a/src/jaxmg/__init__.py
+++ b/src/jaxmg/__init__.py
@@ -112,9 +112,9 @@ if any("gpu" == d.platform for d in jax.devices()):
             jax.ffi.pycapsule(library_potrs_mp.PotrsMgMpFFI),
             platform="CUDA",
         )
-    from ._potrs import potrs, potrs_no_shardmap
+    from ._potrs import potrs, potrs_shardmap_ctx
     from ._potri import potri
-    from ._syevd import syevd
+    from ._syevd import syevd, syevd_shardmap_ctx
 
 else:
     warnings.warn(
@@ -122,9 +122,9 @@ else:
         JaxMgWarning,
         stacklevel=2,
     )
-    from ._potrs import potrs, potrs_no_shardmap
+    from ._potrs import potrs, potrs_shardmap_ctx
     from ._potri import potri
-    from ._syevd import syevd
+    from ._syevd import syevd, syevd_shardmap_ctx
 
     os.environ["JAXMG_NUMBER_OF_DEVICES"] = str(jax.device_count())
 
@@ -139,9 +139,10 @@ from ._cyclic_1d import (
 
 __all__ = [
     "potrs",
-    "potrs_no_shardmap",
+    "potrs_shardmap_ctx",
     "potri",
     "syevd",
+    "syevd_shardmap_ctx",
     "cyclic_1d",
     "pad_rows",
     "unpad_rows",

--- a/src/jaxmg/__init__.py
+++ b/src/jaxmg/__init__.py
@@ -113,7 +113,7 @@ if any("gpu" == d.platform for d in jax.devices()):
             platform="CUDA",
         )
     from ._potrs import potrs, potrs_shardmap_ctx
-    from ._potri import potri
+    from ._potri import potri, potri_shardmap_ctx, potri_symmetrize
     from ._syevd import syevd, syevd_shardmap_ctx
 
 else:
@@ -123,7 +123,7 @@ else:
         stacklevel=2,
     )
     from ._potrs import potrs, potrs_shardmap_ctx
-    from ._potri import potri
+    from ._potri import potri, potri_shardmap_ctx, potri_symmetrize
     from ._syevd import syevd, syevd_shardmap_ctx
 
     os.environ["JAXMG_NUMBER_OF_DEVICES"] = str(jax.device_count())
@@ -141,8 +141,10 @@ __all__ = [
     "potrs",
     "potrs_shardmap_ctx",
     "potri",
+    "potri_shardmap_ctx",
     "syevd",
     "syevd_shardmap_ctx",
+    "potri_symmetrize",
     "cyclic_1d",
     "pad_rows",
     "unpad_rows",

--- a/src/jaxmg/_syevd.py
+++ b/src/jaxmg/_syevd.py
@@ -94,7 +94,7 @@ def syevd(
         - If the native solver fails the outputs may contain NaNs and the
           status (when requested) will be non-zero.
     """
-    ndev =int(os.environ["JAXMG_NUMBER_OF_DEVICES"])
+    ndev = int(os.environ["JAXMG_NUMBER_OF_DEVICES"])
     # Normalize in_specs so it's a single PartitionSpec instance (not an iterable)
     if isinstance(in_specs, (list, tuple)):
         if len(in_specs) != 1:
@@ -191,12 +191,12 @@ def syevd(
     )
     def impl(_a):
         return ffi_fn(_a)
-    
+
     def fn(_a):
         _a = pad_fn(_a)
         if target_name == "syevd_mg":
             _ev, _V, _status = impl(_a)
-            return _ev, unpad_fn(_V), _status
+            return _ev, unpad_fn(_V).T, _status
         else:
             _ev, _status = impl(_a)
             return _ev, _status
@@ -210,3 +210,126 @@ def syevd(
             return out[:-1]
         else:
             return out[0]
+
+
+def syevd_shardmap_ctx(
+    a: Array,
+    T_A: int,
+    return_eigenvectors: bool = True,
+    pad=True,
+) -> Union[Array, Tuple[Array, Array], Tuple[Array, Array, int], Tuple[Array, int]]:
+    """Compute eigenvalues (and optionally eigenvectors) for row-sharded inputs without shard_map wiring.
+
+    This helper is a lightweight, lower-level variant of :func:`syevd` intended
+    for contexts where the input ``a`` is already laid out and sharded at the
+    application level (for example when running inside a custom
+    ``shard_map``/pjit-managed context). It performs the same padding logic
+    driven by ``T_A`` and directly calls the native ``syevd_mg`` /
+    ``syevd_no_V_mg`` FFI targets via ``jax.ffi.ffi_call`` instead of
+    constructing an additional ``shard_map`` wrapper.
+
+    Args:
+        a (Array): 2D JAX array representing the local, row-sharded slice of
+            the global matrix. Shape should be ``(shard_size, N)`` where
+            ``shard_size`` is the per-device (local) row count and ``N`` is the
+            global matrix dimension.
+        T_A (int): Tile width used by the native solver; used to compute any
+            per-device padding required so local shards are multiples of
+            ``T_A``. The implementation enforces an upper bound (e.g.
+            ``T_A <= 1024``).
+        return_eigenvectors (bool, optional): If True (default) compute and
+            return eigenvectors in addition to eigenvalues. When True the
+            returned eigenvector array has the same local/sharded shape as the
+            input (and will be unpadded if padding was applied).
+        pad (bool, optional): If True (default) apply per-device padding to
+            ``a`` to satisfy ``T_A``. If False the caller must ensure the
+            provided local shape already meets kernel requirements.
+
+    Returns:
+        One of the following, depending on ``return_eigenvectors`` and whether
+        the caller requests status:
+            - ``eigenvalues`` (Array, shape ``(N,)``)
+            - ``(eigenvalues, eigenvectors)``
+            - ``(eigenvalues, status)``
+            - ``(eigenvalues, eigenvectors, status)``
+
+    Raises:
+        AssertionError: If ``a`` is not a 2D array.
+        ValueError: If ``T_A`` exceeds implementation limits.
+
+    Notes:
+        - This function does not create a ``jax.shard_map`` wrapper and does
+          not set ``donate_argnums``; it is intended for use when the caller
+          already controls sharding/device placement.
+        - Padding is handled via :func:`calculate_padding`, :func:`pad_rows`,
+          and :func:`unpad_rows` (the latter two are used as local callables
+          rather than shard_map-wrapped functions).
+        - If the native solver fails the outputs may contain NaNs and the
+          returned ``status`` (when present) will be non-zero.
+    """
+    ndev = int(os.environ["JAXMG_NUMBER_OF_DEVICES"])
+    # Normalize in_specs so it's a single PartitionSpec instance (not an iterable)
+    assert a.ndim == 2, "a must be a 2D array."
+    if T_A > 1024:
+        raise ValueError(
+            "T_A has a maximum value of 1024 for SyevdMg, received T_A={T_A}"
+        )
+    shard_size, N = a.shape
+
+    padding = calculate_padding(shard_size, T_A)
+    input_layouts = ((0, 1),)
+    if not pad or padding == 0 or T_A >= N // ndev:
+        if T_A < N // ndev:
+            assert (
+                shard_size == (N + ndev * padding) // ndev
+            ), f"pad=False, but with T_A={T_A}, we need padding of {padding} rows per device."
+            f"Expected {N + ndev * padding} rows, but received {shard_size}"
+
+        # Identity padding
+        pad_fn = lambda _a: _a
+        unpad_fn = lambda _a: _a
+        padding = 0
+
+    else:
+        # Make padding fns
+        pad_fn = partial(pad_rows, padding=padding)
+        unpad_fn = partial(unpad_rows, padding=padding)
+
+    if return_eigenvectors:
+        target_name = "syevd_mg"
+        out_type = (
+            jax.ShapeDtypeStruct((N,), maybe_real_dtype_from_complex(a.dtype)),
+            jax.ShapeDtypeStruct((shard_size + padding, N), a.dtype),
+            jax.ShapeDtypeStruct((1,), jnp.int32),
+        )
+        output_layouts = ((0,), (0, 1), (0,))
+
+    else:
+        target_name = "syevd_no_V_mg"
+        out_type = (
+            jax.ShapeDtypeStruct((N,), maybe_real_dtype_from_complex(a.dtype)),
+            jax.ShapeDtypeStruct((1,), jnp.int32),
+        )
+        output_layouts = ((0,), (0,))
+
+    ffi_fn = partial(
+        jax.ffi.ffi_call(
+            target_name,
+            out_type,
+            input_layouts=input_layouts,
+            output_layouts=output_layouts,
+            input_output_aliases={0: 1} if return_eigenvectors else None,
+        ),
+        T_A=T_A,
+    )
+
+    def fn(_a):
+        _a = pad_fn(_a)
+        if target_name == "syevd_mg":
+            _ev, _V, _status = ffi_fn(_a)
+            return _ev, unpad_fn(_V).T, _status
+        else:
+            _ev, _status = ffi_fn(_a)
+            return _ev, _status
+
+    return fn(a)

--- a/tests/spmd/test_potri.py
+++ b/tests/spmd/test_potri.py
@@ -12,7 +12,7 @@ jax.config.update("jax_enable_x64", True)
 import jax.numpy as jnp
 from jax.sharding import PartitionSpec as P, NamedSharding
 import pytest
-from jaxmg import potri
+from jaxmg import potri, potri_shardmap_ctx, potri_symmetrize
 from jaxmg.utils import random_psd
 from functools import partial
 
@@ -24,16 +24,43 @@ N_list = list(i * ndev for i in [2, 3, 4, 10])
 T_A_list = [1, 2, 3, 5]
 
 
+@partial(jax.jit, static_argnames=("_T_A",))
+def jitted_potri(_a, _T_A):
+    out = partial(potri, mesh=mesh, in_specs=(P("x", None),), pad=True)(_a, _T_A)
+    return out
+
+
+@partial(jax.jit, static_argnames=("_T_A",))
+def jitted_potri_status(_a, _T_A):
+    out, status = partial(
+        potri, mesh=mesh, in_specs=(P("x", None),), pad=True, return_status=True
+    )(_a, _T_A)
+    return out, status
+
+
+@partial(jax.jit, static_argnames=("_T_A",))
+def jitted_potri_no_shardmap(_a, _T_A):
+    out, status = jax.shard_map(
+        partial(potri_shardmap_ctx, T_A=_T_A),
+        mesh=mesh,
+        in_specs=(P("x", None),),
+        out_specs=(P("x", None), P(None)),
+        check_vma=False,
+    )(_a)
+    return out, status
+
+
 def cusolver_solve_arange(N, T_A, dtype):
     A = jnp.diag(jnp.arange(N, dtype=dtype) + 1)
     # Make mesh and place data
-    A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
 
-    out = jax.jit(
-        partial(potri, mesh=mesh, in_specs=(P("x", None),)), static_argnums=1
-    )(A, T_A=T_A)
+    out = jitted_potri(_A.copy(), T_A)
     expected_out = jnp.diag(1.0 / (jnp.arange(N, dtype=dtype) + 1))
     assert jnp.allclose(out, expected_out)
+    expected_out_no_shm, _ = jitted_potri_no_shardmap(_A, T_A)
+    expected_out_no_shm = potri_symmetrize(expected_out_no_shm)
+    assert jnp.allclose(out, expected_out_no_shm)
 
 
 def cusolver_solve_psd(N, T_A, dtype):
@@ -41,23 +68,24 @@ def cusolver_solve_psd(N, T_A, dtype):
     expected_out = jnp.linalg.inv(A)
     # Make mesh and place data
     _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    out = jax.jit(
-        partial(potri, mesh=mesh, in_specs=(P("x", None),)), static_argnums=1
-    )(_A, T_A=T_A)
+    out = jitted_potri(_A, T_A)
     assert jnp.allclose(A.conj().T, A)
     norm_potri = jnp.linalg.norm(A @ out - jnp.eye(N, dtype=dtype))
     norm_lax = jnp.linalg.norm(A @ expected_out - jnp.eye(N, dtype=dtype))
     assert jnp.isclose(norm_potri, norm_lax, rtol=10, atol=0.0)
+    expected_out_no_shm, _ = jitted_potri_no_shardmap(_A, T_A)
+    expected_out_no_shm = potri_symmetrize(expected_out_no_shm)
+    norm_potri_no_shm = jnp.linalg.norm(
+        A @ expected_out_no_shm - jnp.eye(N, dtype=dtype)
+    )
+    assert jnp.allclose(norm_potri_no_shm, norm_lax, rtol=10, atol=0.0)
 
 
 def cusolver_solve_non_psd(N, T_A, dtype):
     A = jnp.diag(jnp.arange(N, dtype=dtype) - 1)
     # Make mesh and place data
     _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    out, status = jax.jit(
-        partial(potri, mesh=mesh, in_specs=(P("x", None),), return_status=True),
-        static_argnums=1,
-    )(_A, T_A=T_A)
+    out, status = jitted_potri_status(_A, T_A)
     status.block_until_ready()
     out.block_until_ready()
     assert status == 7
@@ -67,13 +95,10 @@ def cusolver_solve_non_psd(N, T_A, dtype):
 def cusolver_solve_non_symm(N, T_A, dtype):
     A = jnp.diag(jnp.arange(N, dtype=dtype) + 1)
     # TODO: For some reason the solver does not fail when we set this to 1.0.
-    A = A.at[0,1].set(2.0)
+    A = A.at[0, 1].set(2.0)
     # Make mesh and place data
     _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    out, status = jax.jit(
-        partial(potri, mesh=mesh, in_specs=(P("x", None),), return_status=True),
-        static_argnums=1,
-    )(_A, T_A=T_A)
+    out, status = jitted_potri_status(_A, T_A)
     status.block_until_ready()
     out.block_until_ready()
     assert status == 7

--- a/tests/spmd/test_syevd.py
+++ b/tests/spmd/test_syevd.py
@@ -15,7 +15,7 @@ import pytest
 
 from functools import partial
 
-from jaxmg import syevd
+from jaxmg import syevd, syevd_shardmap_ctx
 from jaxmg.utils import random_psd
 
 devices = [d for d in jax.devices() if d.platform == "gpu"]
@@ -27,58 +27,92 @@ N_list = list(i * ndev for i in [2, 3, 4, 10])
 T_A_list = [1, 2, 3, 5]
 
 
+@partial(jax.jit, static_argnames=("_T_A",))
+def jitted_syevd(_a, _T_A):
+    out = partial(syevd, mesh=mesh, in_specs=(P("x", None),), pad=True)(_a, _T_A)
+    return out
+
+
+@partial(jax.jit, static_argnames=("_T_A",))
+def jitted_syevd_no_shardmap(_a, _T_A):
+    out = jax.shard_map(
+        partial(syevd_shardmap_ctx, T_A=_T_A),
+        mesh=mesh,
+        in_specs=(P("x", None),),
+        out_specs=(P(None), P(None, None), P(None)),
+        check_vma=False,
+    )(_a)
+    return out
+
+
+@partial(jax.jit, static_argnames=("_T_A",))
+def jitted_syevd_no_V(_a, _T_A):
+    out = partial(
+        syevd, mesh=mesh, in_specs=(P("x", None),), return_eigenvectors=False, pad=True
+    )(_a, _T_A)
+    return out
+
+
+@partial(jax.jit, static_argnames=("_T_A",))
+def jitted_syevd_no_V_no_shardmap(_a, _T_A):
+    out = jax.shard_map(
+        partial(syevd_shardmap_ctx, T_A=_T_A, return_eigenvectors=False),
+        mesh=mesh,
+        in_specs=(P("x", None),),
+        out_specs=(P(None), P(None)),
+        check_vma=False,
+    )(_a)
+    return out
+
+
 def cusolver_solve_arange(N, T_A, dtype):
     A = jnp.diag(jnp.arange(N, dtype=dtype) + 1)
     eigenvalues_expected = jnp.diag(A)
     # Make mesh and place data
-    A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    eigenvalues, V = jax.jit(
-        partial(syevd, mesh=mesh, in_specs=(P("x", None),)), static_argnums=1
-    )(A, T_A=T_A)
+    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+    eigenvalues, V = jitted_syevd(_A.copy(), T_A)
     assert jnp.allclose(eigenvalues_expected, eigenvalues)
-    eigenvalus_VtAV = jnp.diag(V.T @ A @ V)
+    eigenvalus_VtAV = jnp.diag(V @ A @ V.T)
     assert jnp.allclose(eigenvalus_VtAV, eigenvalues_expected)
+    eigenvalues_no_shm, V, _ = jitted_syevd_no_shardmap(_A.copy(), T_A)
+    assert jnp.allclose(eigenvalues_expected, eigenvalues_no_shm)
 
 
 def cusolver_solve_psd(N, T_A, dtype):
     A = random_psd(N, dtype=dtype, seed=1234)
     eigenvalues_expected, V_expected = jnp.linalg.eigh(A)
     # Make mesh and place data
-    A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    eigenvalues, V = jax.jit(
-        partial(syevd, mesh=mesh, in_specs=(P("x", None),)), static_argnums=1
-    )(A, T_A=T_A)
-    norm_syevd = jnp.linalg.norm(V.T @ A - jnp.diag(eigenvalues) @ V)
+    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+    eigenvalues, V = jitted_syevd(_A.copy(), T_A)
+    norm_syevd = jnp.linalg.norm(V @ A - jnp.diag(eigenvalues) @ V.T)
     norm_lax = jnp.linalg.norm(
-        V_expected.T @ A - jnp.diag(eigenvalues_expected) @ V_expected
+        V_expected @ A - jnp.diag(eigenvalues_expected) @ V_expected.T
     )
     assert jnp.isclose(norm_syevd, norm_lax, rtol=10, atol=0.0)
+    eigenvalues_no_shm, V, _ = jitted_syevd_no_shardmap(_A.copy(), T_A)
+    assert jnp.allclose(eigenvalues_expected, eigenvalues_no_shm, rtol=10, atol=0.0)
 
 
 def cusolver_solve_arange_no_V(N, T_A, dtype):
     A = jnp.diag(jnp.arange(N, dtype=dtype) + 1)
     eigenvalues_expected = jnp.diag(A)
     # Make mesh and place data
-    A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-
-    eigenvalues = jax.jit(
-        partial(syevd, mesh=mesh, in_specs=(P("x", None),), return_eigenvectors=False),
-        static_argnums=1,
-    )(A, T_A=T_A)
-    assert jnp.allclose(eigenvalues_expected, eigenvalues, rtol=10, atol=0.0)
+    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+    eigenvalues = jitted_syevd_no_V(_A.copy(), T_A)
+    assert jnp.allclose(eigenvalues_expected, eigenvalues)
+    eigenvalues_no_shm, _ = jitted_syevd_no_V_no_shardmap(_A.copy(), T_A)
+    assert jnp.allclose(eigenvalues_expected, eigenvalues_no_shm)
 
 
 def cusolver_solve_psd_no_V(N, T_A, dtype):
     A = random_psd(N, dtype=dtype, seed=1234)
     eigenvalues_expected = jnp.linalg.eigvalsh(A)
     # Make mesh and place data
-    A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    eigenvalues = jax.jit(
-        partial(syevd, mesh=mesh, in_specs=(P("x", None),), return_eigenvectors=False),
-        static_argnums=1,
-    )(A, T_A=T_A)
-
+    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+    eigenvalues = jitted_syevd_no_V(A.copy(), T_A)
     assert jnp.allclose(eigenvalues, eigenvalues_expected, rtol=10, atol=0.0)
+    eigenvalues_no_shm, _ = jitted_syevd_no_V_no_shardmap(_A.copy(), T_A)
+    assert jnp.allclose(eigenvalues_expected, eigenvalues_no_shm, rtol=10, atol=0.0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Created three aliases `potrs_shardmap_ctx`, `syevd_shardmap_ctx` and `potri_shardmap_ctx` that have to be called in a shard map context.