### PR TITLE
Compile wheels online

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -56,8 +56,8 @@ jobs:
             # Use CUDA 12.6 as it's widely available and compatible with JAX >= 0.6.0
             yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
             yum clean all
-            # Install core CUDA toolkit and specific libraries needed
-            yum -y --nogpgcheck install cuda-toolkit-12-6 cuda-cusolver-12-6 cuda-cupti-12-6
+            # Install core CUDA toolkit (includes all libraries)
+            yum -y --nogpgcheck install cuda-toolkit-12-6
 
             # Install cuDNN from CUDA repository (try libcudnn9-cuda-12)
             yum -y --nogpgcheck install libcudnn9-cuda-12 libcudnn9-devel-cuda-12 || echo "cuDNN not available in repo, skipping"

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -74,6 +74,12 @@ jobs:
             ls -la /usr/local/cuda/lib64/ | grep -i cusolver || echo "No cusolver libs found"
             find /usr/local/cuda -name "*cusolverMg*" || echo "cusolverMg not found"
 
+            # Check CUPTI location
+            echo "=== Looking for CUPTI ==="
+            find /usr/local/cuda -name "cupti.h" 2>/dev/null || echo "cupti.h not found in /usr/local/cuda"
+            ls -la /usr/local/cuda/extras/ 2>/dev/null || echo "No extras directory"
+            ls -la /usr/local/cuda/include/ | grep -i cupti || echo "No CUPTI in include"
+
           # Set environment variables for the build
           CIBW_ENVIRONMENT: |
             CUDA_ROOT=/usr/local/cuda

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -46,8 +46,8 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: |
             set -ex
 
-            # Install basic dependencies
-            yum install -y wget git cmake3 gcc-toolset-11 gcc-toolset-11-gcc-c++
+            # Install basic dependencies (--nogpgcheck to skip GPG verification in manylinux container)
+            yum install -y --nogpgcheck wget git cmake3 gcc-toolset-11 gcc-toolset-11-gcc-c++
 
             # Enable GCC 11
             source /opt/rh/gcc-toolset-11/enable
@@ -56,7 +56,7 @@ jobs:
             wget https://developer.download.nvidia.com/compute/cuda/12.8.0/local_installers/cuda-repo-rhel8-12-8-local-12.8.0_550.54.15-1.x86_64.rpm
             rpm -i cuda-repo-rhel8-12-8-local-12.8.0_550.54.15-1.x86_64.rpm
             yum clean all
-            yum -y install cuda-toolkit-12-8
+            yum -y --nogpgcheck install cuda-toolkit-12-8
 
             # Install cuDNN 9.2 (requires NVIDIA developer account, using public link if available)
             # Note: This may need to be updated with actual cuDNN installation

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,132 @@
+name: Build CUDA Wheels
+
+on:
+  push:
+    tags: ['v*']
+  pull_request:
+    paths:
+      - '.github/workflows/build-wheels.yml'
+      - 'pyproject.toml'
+      - 'CMakeLists.txt'
+      - 'src/cuda/**'
+  workflow_dispatch:
+
+jobs:
+  build_wheels:
+    name: Build wheels on Linux
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.16.2
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          # Only build for CPython 3.9, 3.10, 3.11, 3.12 on Linux x86_64
+          CIBW_BUILD: "cp39-manylinux_x86_64 cp310-manylinux_x86_64 cp311-manylinux_x86_64 cp312-manylinux_x86_64"
+
+          # Skip PyPy, musllinux, Windows, and macOS
+          CIBW_SKIP: "pp* *-musllinux_*"
+
+          # Use manylinux_2_28 for GCC 11 support
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+
+          # Install CUDA Toolkit and dependencies before building all wheels
+          CIBW_BEFORE_ALL_LINUX: |
+            set -ex
+
+            # Install basic dependencies
+            yum install -y wget git cmake3 gcc-toolset-11 gcc-toolset-11-gcc-c++
+
+            # Enable GCC 11
+            source /opt/rh/gcc-toolset-11/enable
+
+            # Install CUDA Toolkit 12.8
+            wget https://developer.download.nvidia.com/compute/cuda/12.8.0/local_installers/cuda-repo-rhel8-12-8-local-12.8.0_550.54.15-1.x86_64.rpm
+            rpm -i cuda-repo-rhel8-12-8-local-12.8.0_550.54.15-1.x86_64.rpm
+            yum clean all
+            yum -y install cuda-toolkit-12-8
+
+            # Install cuDNN 9.2 (requires NVIDIA developer account, using public link if available)
+            # Note: This may need to be updated with actual cuDNN installation
+            # For now, we'll download from a specific location
+            wget https://developer.download.nvidia.com/compute/cudnn/9.2.0/local_installers/cudnn-linux-x86_64-9.2.0.82_cuda12-archive.tar.xz
+            tar -xf cudnn-linux-x86_64-9.2.0.82_cuda12-archive.tar.xz
+            cp -r cudnn-linux-x86_64-9.2.0.82_cuda12-archive /usr/local/cudnn-9.2
+
+            # Verify installations
+            ls -la /usr/local/cuda-12.8/
+            ls -la /usr/local/cudnn-9.2/
+
+          # Set environment variables for the build
+          CIBW_ENVIRONMENT: |
+            CUDA_ROOT=/usr/local/cuda-12.8
+            CUDNN_ROOT=/usr/local/cudnn-9.2
+            PATH=/usr/local/cuda-12.8/bin:$PATH
+            LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64:$LD_LIBRARY_PATH
+
+          # Build the CUDA libraries before building the wheel
+          CIBW_BEFORE_BUILD: |
+            set -ex
+
+            # Enable GCC 11
+            source /opt/rh/gcc-toolset-11/enable
+
+            # Set environment variables
+            export CUDA_ROOT=/usr/local/cuda-12.8
+            export CUDNN_ROOT=/usr/local/cudnn-9.2
+            export PATH=/usr/local/cuda-12.8/bin:$PATH
+            export LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64:$LD_LIBRARY_PATH
+
+            # Build using CMake
+            mkdir -p build
+            cd build
+            cmake3 -DCMAKE_BUILD_TYPE=Release ..
+            cmake3 --build . --target install -- -j$(nproc)
+            cd ..
+
+            # Verify the shared libraries were built
+            ls -la src/jaxmg/bin/
+
+          # Custom auditwheel repair to exclude CUDA libraries
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: |
+            auditwheel repair -w {dest_dir} {wheel} \
+              --exclude libcusolver.so.12 \
+              --exclude libcusolverMg.so.12 \
+              --exclude libcudart.so.12 \
+              --exclude libcublas.so.12 \
+              --exclude libcublasLt.so.12 \
+              --exclude libcupti.so.12 \
+              --exclude libcuda.so.1 \
+              --exclude libcudnn.so.9
+
+          # Run tests after building (optional, requires GPU in CI)
+          # CIBW_TEST_COMMAND: "pytest {project}/tests"
+          # For now, skip tests as they require GPU
+          CIBW_TEST_SKIP: "*"
+
+      - name: Upload wheels as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: jaxmg-wheels-${{ github.sha }}
+          path: ./wheelhouse/*.whl
+          retention-days: 30
+
+      - name: Display wheel info
+        run: |
+          ls -lh wheelhouse/
+          for wheel in wheelhouse/*.whl; do
+            echo "=== $wheel ==="
+            unzip -l "$wheel" | grep "\.so$" || echo "No .so files found"
+          done

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -52,29 +52,28 @@ jobs:
             # Enable GCC 11
             source /opt/rh/gcc-toolset-11/enable
 
-            # Install CUDA Toolkit 12.8
-            wget https://developer.download.nvidia.com/compute/cuda/12.8.0/local_installers/cuda-repo-rhel8-12-8-local-12.8.0_550.54.15-1.x86_64.rpm
-            rpm -i cuda-repo-rhel8-12-8-local-12.8.0_550.54.15-1.x86_64.rpm
+            # Install CUDA Toolkit 12.6 (using network repository)
+            # Use CUDA 12.6 as it's widely available and compatible with JAX >= 0.6.0
+            yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
             yum clean all
-            yum -y --nogpgcheck install cuda-toolkit-12-8
+            yum -y --nogpgcheck install cuda-toolkit-12-6
 
-            # Install cuDNN 9.2 (requires NVIDIA developer account, using public link if available)
-            # Note: This may need to be updated with actual cuDNN installation
-            # For now, we'll download from a specific location
-            wget https://developer.download.nvidia.com/compute/cudnn/9.2.0/local_installers/cudnn-linux-x86_64-9.2.0.82_cuda12-archive.tar.xz
-            tar -xf cudnn-linux-x86_64-9.2.0.82_cuda12-archive.tar.xz
-            cp -r cudnn-linux-x86_64-9.2.0.82_cuda12-archive /usr/local/cudnn-9.2
+            # Install cuDNN from CUDA repository (try libcudnn9-cuda-12)
+            yum -y --nogpgcheck install libcudnn9-cuda-12 libcudnn9-devel-cuda-12 || echo "cuDNN not available in repo, skipping"
+
+            # Create symlink for easier path reference
+            ln -sf /usr/local/cuda-12.6 /usr/local/cuda
 
             # Verify installations
-            ls -la /usr/local/cuda-12.8/
-            ls -la /usr/local/cudnn-9.2/
+            ls -la /usr/local/cuda/
+            nvcc --version || echo "NVCC not found"
 
           # Set environment variables for the build
           CIBW_ENVIRONMENT: |
-            CUDA_ROOT=/usr/local/cuda-12.8
-            CUDNN_ROOT=/usr/local/cudnn-9.2
-            PATH=/usr/local/cuda-12.8/bin:$PATH
-            LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64:$LD_LIBRARY_PATH
+            CUDA_ROOT=/usr/local/cuda
+            CUDNN_ROOT=/usr
+            PATH=/usr/local/cuda/bin:$PATH
+            LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 
           # Build the CUDA libraries before building the wheel
           CIBW_BEFORE_BUILD: |
@@ -84,10 +83,10 @@ jobs:
             source /opt/rh/gcc-toolset-11/enable
 
             # Set environment variables
-            export CUDA_ROOT=/usr/local/cuda-12.8
-            export CUDNN_ROOT=/usr/local/cudnn-9.2
-            export PATH=/usr/local/cuda-12.8/bin:$PATH
-            export LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64:$LD_LIBRARY_PATH
+            export CUDA_ROOT=/usr/local/cuda
+            export CUDNN_ROOT=/usr
+            export PATH=/usr/local/cuda/bin:$PATH
+            export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 
             # Build using CMake
             mkdir -p build

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -56,7 +56,8 @@ jobs:
             # Use CUDA 12.6 as it's widely available and compatible with JAX >= 0.6.0
             yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
             yum clean all
-            yum -y --nogpgcheck install cuda-toolkit-12-6
+            # Install core CUDA toolkit and specific libraries needed
+            yum -y --nogpgcheck install cuda-toolkit-12-6 cuda-cusolver-12-6 cuda-cupti-12-6
 
             # Install cuDNN from CUDA repository (try libcudnn9-cuda-12)
             yum -y --nogpgcheck install libcudnn9-cuda-12 libcudnn9-devel-cuda-12 || echo "cuDNN not available in repo, skipping"
@@ -67,6 +68,11 @@ jobs:
             # Verify installations
             ls -la /usr/local/cuda/
             nvcc --version || echo "NVCC not found"
+
+            # List available CUDA libraries
+            echo "=== CUDA lib64 contents ==="
+            ls -la /usr/local/cuda/lib64/ | grep -i cusolver || echo "No cusolver libs found"
+            find /usr/local/cuda -name "*cusolverMg*" || echo "cusolverMg not found"
 
           # Set environment variables for the build
           CIBW_ENVIRONMENT: |

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          # Only build for CPython 3.9, 3.10, 3.11, 3.12 on Linux x86_64
-          CIBW_BUILD: "cp39-manylinux_x86_64 cp310-manylinux_x86_64 cp311-manylinux_x86_64 cp312-manylinux_x86_64"
+          # Only build for CPython 3.11, 3.12, 3.13, 3.14 on Linux x86_64
+          CIBW_BUILD: "cp311-manylinux_x86_64 cp312-manylinux_x86_64 cp313-manylinux_x86_64 cp314-manylinux_x86_64"
 
           # Skip PyPy, musllinux, Windows, and macOS
           CIBW_SKIP: "pp* *-musllinux_*"

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -76,9 +76,15 @@ jobs:
 
             # Check CUPTI location
             echo "=== Looking for CUPTI ==="
-            find /usr/local/cuda -name "cupti.h" 2>/dev/null || echo "cupti.h not found in /usr/local/cuda"
-            ls -la /usr/local/cuda/extras/ 2>/dev/null || echo "No extras directory"
-            ls -la /usr/local/cuda/include/ | grep -i cupti || echo "No CUPTI in include"
+            ls -la /usr/local/cuda/extras/CUPTI/ 2>/dev/null || echo "No CUPTI extras"
+            ls -la /usr/local/cuda/extras/CUPTI/include/ 2>/dev/null || echo "No CUPTI include in extras"
+
+            # CUPTI headers are in /usr/local/cuda/include/, not extras/CUPTI/include/
+            # Create symlink from extras/CUPTI/include to main include directory
+            mkdir -p /usr/local/cuda/extras/CUPTI
+            ln -sfn /usr/local/cuda/include /usr/local/cuda/extras/CUPTI/include
+            echo "Created CUPTI symlink:"
+            ls -la /usr/local/cuda/extras/CUPTI/include/cupti*.h
 
           # Set environment variables for the build
           CIBW_ENVIRONMENT: |

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -94,6 +94,11 @@ jobs:
             export PATH=/usr/local/cuda/bin:$PATH
             export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 
+            # Create required symlinks for JAX build (JAX expects CUDA at third_party/gpus/cuda)
+            mkdir -p third_party/gpus
+            ln -sfn /usr/local/cuda third_party/gpus/cuda
+            ls -la third_party/gpus/
+
             # Build using CMake
             mkdir -p build
             cd build

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.16.2
+        run: python -m pip install cibuildwheel==3.3.0
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -47,7 +47,7 @@ jobs:
             set -ex
 
             # Install basic dependencies (--nogpgcheck to skip GPG verification in manylinux container)
-            yum install -y --nogpgcheck wget git cmake3 gcc-toolset-11 gcc-toolset-11-gcc-c++
+            yum install -y --nogpgcheck wget git cmake3 gcc-toolset-11 gcc-toolset-11-gcc-c++ yum-utils
 
             # Enable GCC 11
             source /opt/rh/gcc-toolset-11/enable

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# Build artifacts
+build/
+dist/
+wheelhouse/
+*.egg-info/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+
+# CMake
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+Makefile
+*.cmake
+
+# Symlinks created during build
+third_party/
+xla/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Python
+.pytest_cache/
+.coverage
+htmlcov/
+
+# OS
+.DS_Store
+Thumbs.db

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,9 @@ CPMAddPackage(
 
 # Import CUDAToolkit (Requires CUDA_HOME to be set)
 find_package(CUDAToolkit REQUIRED)
-find_library(CUSOLVERMG_LIB cusolverMg HINTS "${CUDA_TOOLKIT_ROOT_DIR}/lib64" REQUIRED)
+find_library(CUSOLVERMG_LIB cusolverMg
+    HINTS "${CUDAToolkit_LIBRARY_DIR}" "${CUDA_TOOLKIT_ROOT_DIR}/lib64" "/usr/local/cuda/lib64"
+    REQUIRED)
 # Import CUDAToolkit (Requires CUDA_HOME to be set)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" ${CMAKE_MODULE_PATH})
 find_package(CUDNN REQUIRED)

--- a/WHEEL_BUILD.md
+++ b/WHEEL_BUILD.md
@@ -1,0 +1,135 @@
+# Building Wheels for jaxmg
+
+This document explains how to build distributable wheels for jaxmg with CUDA support.
+
+## Overview
+
+The project uses `cibuildwheel` to build manylinux wheels with pre-compiled CUDA libraries. This allows users to install jaxmg without needing to compile the CUDA code themselves.
+
+## CI Build Process
+
+Wheels are automatically built on GitHub Actions when:
+- A tag matching `v*` is pushed (e.g., `v0.1.0`)
+- The workflow is manually triggered via workflow_dispatch
+- Changes are made to the build configuration files
+
+### What the CI does:
+
+1. **Sets up build environment**: Uses manylinux_2_28 Docker image with GCC 11
+2. **Installs CUDA Toolkit 12.8** and cuDNN 9.2
+3. **Compiles CUDA libraries**: Runs CMake to build the 6 shared libraries (.so files)
+4. **Creates wheels**: Packages the compiled libraries with the Python code
+5. **Repairs wheels**: Uses auditwheel to create manylinux-compliant wheels, excluding CUDA runtime libraries
+6. **Uploads artifacts**: Wheels are uploaded as GitHub Actions artifacts (30-day retention)
+
+### Supported configurations:
+
+- **Python versions**: 3.9, 3.10, 3.11, 3.12
+- **Platform**: Linux x86_64 only
+- **CUDA version**: 12.8 (compatible with JAX CUDA 12.x)
+
+## Local Testing
+
+To test the wheel build process locally:
+
+```bash
+# Install cibuildwheel
+pip install cibuildwheel==2.16.2
+
+# Build wheels (requires Docker)
+cibuildwheel --platform linux --output-dir wheelhouse
+
+# This will take significant time on first run as it downloads CUDA
+```
+
+## Using Pre-built Wheels
+
+Once wheels are built in CI:
+
+1. Go to the GitHub Actions run
+2. Download the `jaxmg-wheels-*` artifact
+3. Extract and install:
+
+```bash
+pip install jaxmg-0.1.0-cp311-cp311-manylinux_2_28_x86_64.whl
+```
+
+Or install with CUDA dependencies:
+
+```bash
+pip install jaxmg-0.1.0-cp311-cp311-manylinux_2_28_x86_64.whl
+pip install "jax[cuda12]>=0.6.2"
+```
+
+## Important Notes
+
+### CUDA Runtime Dependencies
+
+The wheels **do not include** CUDA runtime libraries. Users must have CUDA libraries available through one of:
+
+1. **JAX CUDA installation** (recommended):
+   ```bash
+   pip install "jax[cuda12]>=0.6.2"
+   ```
+   JAX ships with CUDA 12.x runtime libraries.
+
+2. **System CUDA installation**: CUDA 12.1+ installed on the system
+
+3. **NVIDIA Container Runtime**: When running in Docker with NVIDIA runtime
+
+### Excluded Libraries
+
+The following CUDA libraries are excluded from the wheel (users get them via JAX or system CUDA):
+
+- `libcusolver.so.12`
+- `libcusolverMg.so.12`
+- `libcudart.so.12`
+- `libcublas.so.12`
+- `libcublasLt.so.12`
+- `libcupti.so.12`
+- `libcuda.so.1`
+- `libcudnn.so.9`
+
+### Wheel Size
+
+Without bundling CUDA libraries, wheels are approximately 12-15 MB each (for the 6 compiled .so files). With CUDA libraries bundled, they would be 400+ MB.
+
+## Future Improvements
+
+- [ ] Add wheel building for CUDA 13 when JAX migrates
+- [ ] Consider building wheels for multiple CUDA versions (12.x, 13.x)
+- [ ] Add automated PyPI publishing (currently only GitHub artifacts)
+- [ ] Add wheel verification tests
+
+## Troubleshooting
+
+### cuDNN Download Issues
+
+The current workflow downloads cuDNN 9.2 from NVIDIA. If this URL becomes unavailable, you may need to:
+
+1. Host cuDNN in a more permanent location
+2. Use a different cuDNN version (ensure compatibility)
+3. Modify the `CIBW_BEFORE_ALL_LINUX` step in the workflow
+
+### Build Failures
+
+Common issues:
+
+- **CUDA not found**: Check that CUDA_ROOT and CUDNN_ROOT are set correctly
+- **GCC version**: Must use GCC 11 for C++20 support
+- **CMake version**: Use cmake3 on manylinux images
+- **Missing symlinks**: CMake build creates symlinks to CUDA/cuDNN, ensure they're created successfully
+
+### Testing Wheels
+
+To test a wheel without GPU access:
+
+```bash
+# Install the wheel
+pip install wheelhouse/jaxmg-*.whl
+
+# Import should work (though running code requires GPU)
+python -c "import jaxmg; print(jaxmg.__version__)"
+```
+
+For full testing, you need a system with NVIDIA GPU and CUDA runtime.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,13 @@ docs = [
     "mkdocs-ipynb==0.1.1",
     "hippogriffe==0.2.2",
 ]
+
+[tool.cibuildwheel]
+# Only build for Linux x86_64 (no macOS, Windows, or other architectures)
+build = ["cp39-manylinux_x86_64", "cp310-manylinux_x86_64", "cp311-manylinux_x86_64", "cp312-manylinux_x86_64"]
+
+# Use manylinux_2_28 for GCC 11 support
+manylinux-x86_64-image = "manylinux_2_28"
+
+# Skip tests during wheel build (requires GPU)
+test-skip = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Python wrapper around cuSolverMg with JAX support"
 authors = [{ name = "Roeland Wiersema" }]
 dependencies = ["pytest==8.2.1", "matplotlib>=3.10.3"]
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 
 [tool.setuptools.packages.find]
 where = ["src"]
@@ -38,7 +38,7 @@ docs = [
 
 [tool.cibuildwheel]
 # Only build for Linux x86_64 (no macOS, Windows, or other architectures)
-build = ["cp39-manylinux_x86_64", "cp310-manylinux_x86_64", "cp311-manylinux_x86_64", "cp312-manylinux_x86_64"]
+build = ["cp311-manylinux_x86_64", "cp312-manylinux_x86_64", "cp313-manylinux_x86_64", "cp314-manylinux_x86_64"]
 
 # Use manylinux_2_28 for GCC 11 support
 manylinux-x86_64-image = "manylinux_2_28"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup
+from setuptools.dist import Distribution
+
+
+class BinaryDistribution(Distribution):
+    """Distribution which always forces a binary package with platform name"""
+    def has_ext_modules(self):
+        return True
+
+
+setup(
+    distclass=BinaryDistribution,
+)


### PR DESCRIPTION
Hi Roeland, you triggered me... so I triggered Claude.

I am a fan of having stuff that is easy to run everywhere and I came to hate complex installation procedures.
So I asked Claude to use CIBuildWheel to compile wheels in CI, which you could upload to pypi

After 2 hours of Claude fighting against CI, he managed to win! (it would have taken me far far longer).
I still need to review and cleanup this PR to something that is reasonable, but I just tested it and it does work.

If you download the wheels from https://github.com/PhilipVinc/jaxmg/actions/runs/19687459515 you can install them manually and see that you don't need to have the compile them yourself.