### PR TITLE
Fix race condition for shm and add multi-processing for potri and syevd.

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
             }
 
             options {
-                timeout(time: 60, unit: 'MINUTES')
+                timeout(time: 120, unit: 'MINUTES')
             }
             stages {
                 stage('Compile') {

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
             }
 
             options {
-                timeout(time: 60, unit: 'MINUTES')
+                timeout(time: 120, unit: 'MINUTES')
             }
             stages {
                 stage('Compile') {

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -1,5 +1,8 @@
 pipeline {
     agent none
+    triggers {
+        cron '@monthly'
+    }
     stages {
         stage('Compile CUDA 12') {
             agent {
@@ -143,7 +146,6 @@ pipeline {
                                                     python -c "import sys, jax; print(f'Python {sys.version_info[:2]}, JAX {jax.__version__}'); print(jax.devices()); import jaxmg"
                                                 '''
                                                 archiveArtifacts artifacts: "${WORKDIR}/dist_repaired/*.whl", onlyIfSuccessful: true
-                                            
                                             }
                                         }
                                         stage("Test ${c}-${p}-${j}") {

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -1,5 +1,8 @@
 pipeline {
     agent none
+    options {
+        timeout(time: 2, unit: 'HOURS')
+    }
     triggers {
         cron '@monthly'
     }
@@ -11,10 +14,6 @@ pipeline {
                     args '--gpus=2 --shm-size=4gb'
                     label 'docker && v100'
                 }
-            }
-
-            options {
-                timeout(time: 120, unit: 'MINUTES')
             }
             stages {
                 stage('Compile') {
@@ -48,10 +47,6 @@ pipeline {
                     label 'docker && v100'
                 }
             }
-
-            options {
-                timeout(time: 120, unit: 'MINUTES')
-            }
             stages {
                 stage('Compile') {
                     environment {
@@ -83,9 +78,6 @@ pipeline {
                     args '--gpus=2 --shm-size=4gb'
                     label 'docker && v100'
                 }
-            }
-            options {
-                timeout(time: 60, unit: 'MINUTES')
             }
             stages {
                 stage('Build + Test') {
@@ -188,9 +180,6 @@ pipeline {
                     args '--gpus=2 --shm-size=4gb'
                     label 'docker && v100'
                 }
-            }
-            options {
-                timeout(time: 60, unit: 'MINUTES')
             }
             stages {
                 stage('Build + Test') {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,13 @@ endif()
 
 # Set JAX_GPU_CUDA to 1 (this is required for jaxlib to compile correctly)
 add_definitions(-DJAX_GPU_CUDA=1)
+# Suppress host CUDA warning
+add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:-diag-suppress=940,2473,2810>)
+# Suppress host C++ warnings from GCC/Clang (only for C++ sources)
+add_compile_options(
+  $<$<COMPILE_LANGUAGE:CXX>:-Wno-return-type>
+  $<$<COMPILE_LANGUAGE:CXX>:-Wno-attributes>
+)
 # Add libraries
 add_library(cyclic SHARED
     src/cuda/cyclic.cu

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,16 +147,37 @@ add_library(potri SHARED
     src/cuda/utils/shm.cc
     ${jax_SOURCE_DIR}/jaxlib/gpu/gpu_kernel_helpers.cc
 )
+add_library(potri_mp SHARED
+    src/cuda/potri_mp.cu
+    src/cuda/utils/jax_utils.cc
+    src/cuda/utils/shm.cc
+    src/cuda/utils/ipc_utils.cc
+    ${jax_SOURCE_DIR}/jaxlib/gpu/gpu_kernel_helpers.cc
+)
 add_library(syevd SHARED
     src/cuda/syevd.cu
     src/cuda/utils/jax_utils.cc
     src/cuda/utils/shm.cc
     ${jax_SOURCE_DIR}/jaxlib/gpu/gpu_kernel_helpers.cc
 )
+add_library(syevd_mp SHARED
+    src/cuda/syevd_mp.cu
+    src/cuda/utils/jax_utils.cc
+    src/cuda/utils/shm.cc
+    src/cuda/utils/ipc_utils.cc
+    ${jax_SOURCE_DIR}/jaxlib/gpu/gpu_kernel_helpers.cc
+)
 add_library(syevd_no_V SHARED
     src/cuda/syevd_no_V.cu
     src/cuda/utils/jax_utils.cc
     src/cuda/utils/shm.cc
+    ${jax_SOURCE_DIR}/jaxlib/gpu/gpu_kernel_helpers.cc
+)
+add_library(syevd_no_V_mp SHARED
+    src/cuda/syevd_no_V_mp.cu
+    src/cuda/utils/jax_utils.cc
+    src/cuda/utils/shm.cc
+    src/cuda/utils/ipc_utils.cc
     ${jax_SOURCE_DIR}/jaxlib/gpu/gpu_kernel_helpers.cc
 )
 
@@ -167,8 +188,11 @@ target_include_directories(cyclic PUBLIC ${CMAKE_SOURCE_DIR} ${jax_SOURCE_DIR} $
 target_include_directories(potrs PUBLIC ${CMAKE_SOURCE_DIR} ${jax_SOURCE_DIR} ${SRC_CUDA_INCLUDE} ${SRC_CUDA_ROOT})
 target_include_directories(potrs_mp PUBLIC ${CMAKE_SOURCE_DIR} ${jax_SOURCE_DIR} ${SRC_CUDA_INCLUDE} ${SRC_CUDA_ROOT})
 target_include_directories(potri PUBLIC ${CMAKE_SOURCE_DIR} ${jax_SOURCE_DIR} ${SRC_CUDA_INCLUDE} ${SRC_CUDA_ROOT})
+target_include_directories(potri_mp PUBLIC ${CMAKE_SOURCE_DIR} ${jax_SOURCE_DIR} ${SRC_CUDA_INCLUDE} ${SRC_CUDA_ROOT})
 target_include_directories(syevd PUBLIC ${CMAKE_SOURCE_DIR} ${jax_SOURCE_DIR} ${SRC_CUDA_INCLUDE} ${SRC_CUDA_ROOT})
+target_include_directories(syevd_mp PUBLIC ${CMAKE_SOURCE_DIR} ${jax_SOURCE_DIR} ${SRC_CUDA_INCLUDE} ${SRC_CUDA_ROOT})
 target_include_directories(syevd_no_V PUBLIC ${CMAKE_SOURCE_DIR} ${jax_SOURCE_DIR} ${SRC_CUDA_INCLUDE} ${SRC_CUDA_ROOT})
+target_include_directories(syevd_no_V_mp PUBLIC ${CMAKE_SOURCE_DIR} ${jax_SOURCE_DIR} ${SRC_CUDA_INCLUDE} ${SRC_CUDA_ROOT})
 
 # Set the CUDA architecture
 set_target_properties(cyclic PROPERTIES
@@ -183,10 +207,19 @@ set_target_properties(potrs_mp PROPERTIES
 set_target_properties(potri PROPERTIES
     CUDA_ARCHITECTURES "all"
 )
+set_target_properties(potri_mp PROPERTIES
+    CUDA_ARCHITECTURES "all"
+)
 set_target_properties(syevd PROPERTIES
     CUDA_ARCHITECTURES "all"
 )
+set_target_properties(syevd_mp PROPERTIES
+    CUDA_ARCHITECTURES "all"
+)
 set_target_properties(syevd_no_V PROPERTIES
+    CUDA_ARCHITECTURES "all"
+)
+set_target_properties(syevd_no_V_mp PROPERTIES
     CUDA_ARCHITECTURES "all"
 )
 
@@ -228,7 +261,25 @@ target_link_libraries(potri
     ${CUSOLVERMG_LIB}
     cuda
 )
+target_link_libraries(potri_mp
+    absl::strings
+    absl::status
+    absl::statusor
+    CUDA::cusolver
+    CUDA::cupti
+    ${CUSOLVERMG_LIB}
+    cuda
+)
 target_link_libraries(syevd
+    absl::strings
+    absl::status
+    absl::statusor
+    CUDA::cusolver
+    CUDA::cupti
+    ${CUSOLVERMG_LIB}
+    cuda
+)
+target_link_libraries(syevd_mp
     absl::strings
     absl::status
     absl::statusor
@@ -239,6 +290,15 @@ target_link_libraries(syevd
 )
 
 target_link_libraries(syevd_no_V
+    absl::strings
+    absl::status
+    absl::statusor
+    CUDA::cusolver
+    CUDA::cupti
+    ${CUSOLVERMG_LIB}
+    cuda
+)
+target_link_libraries(syevd_no_V_mp
     absl::strings
     absl::status
     absl::statusor
@@ -260,10 +320,19 @@ install(TARGETS potrs_mp
 install(TARGETS potri
     LIBRARY DESTINATION ${CMAKE_SOURCE_DIR}/${BIN_DST}
 )
+install(TARGETS potri_mp
+    LIBRARY DESTINATION ${CMAKE_SOURCE_DIR}/${BIN_DST}
+)
 install(TARGETS syevd
     LIBRARY DESTINATION ${CMAKE_SOURCE_DIR}/${BIN_DST}
 )
+install(TARGETS syevd_mp
+    LIBRARY DESTINATION ${CMAKE_SOURCE_DIR}/${BIN_DST}
+)
 install(TARGETS syevd_no_V
+    LIBRARY DESTINATION ${CMAKE_SOURCE_DIR}/${BIN_DST}
+)
+install(TARGETS syevd_no_V_mp
     LIBRARY DESTINATION ${CMAKE_SOURCE_DIR}/${BIN_DST}
 )
 

--- a/docs/examples/spmd_mpmd.ipynb
+++ b/docs/examples/spmd_mpmd.ipynb
@@ -6,7 +6,6 @@
    "metadata": {},
    "source": [
     "# MPMD support\n",
-    "> **_Note:_**  Multi-process multiple device (MPMD) mode is only supported for `potrs` but will be available for `potri` and `syevd` in a future release.\n",
     "    \n",
     "We support two modes of distributed computing. Single Process Multiple Devices mode (SPMD), where we have\n",
     "a single process per node that potentially manages multiple devices. We also support MPMD mode (MPMD). Here the user needs to\n",

--- a/docs/technical_details/col_maj.md
+++ b/docs/technical_details/col_maj.md
@@ -8,32 +8,32 @@ avoids the extra copy by presenting per-device buffers already in the solver's
 expected column-major order.
 
 Row-major vs column-major
-- Row-major (C order): rows are laid out contiguously. For an $m\\times n$
-	matrix $A$ the memory is the concatenation of rows $1,2,\\dots,m$.
+- Row-major (C order): rows are laid out contiguously. For an $m\times n$
+	matrix $A$ the memory is the concatenation of rows $1,2,\dots,m$.
 - Column-major (Fortran order): columns are laid out contiguously. The
-	memory is the concatenation of columns $1,2,\\dots,n$.
+	memory is the concatenation of columns $1,2,\dots,n$.
 
-Concretely, for a small $4\\times 4$ matrix
+Concretely, for a small $4\times 4$ matrix
 
 $$
-A = \\begin{bmatrix}
-a_{11} & a_{12} & a_{13} & a_{14} \\\\
-a_{21} & a_{22} & a_{23} & a_{24} \\\\
-a_{31} & a_{32} & a_{33} & a_{34} \\\\
+A = \begin{bmatrix}
+a_{11} & a_{12} & a_{13} & a_{14} \\
+a_{21} & a_{22} & a_{23} & a_{24} \\
+a_{31} & a_{32} & a_{33} & a_{34} \\
 a_{41} & a_{42} & a_{43} & a_{44}
-\\end{bmatrix}
+\end{bmatrix}
 $$
 
 - Row-major flattening (C order) produces
 
 $$
-\\operatorname{row\\_major}(A) = [a_{11}, a_{12}, a_{13}, a_{14},\\; a_{21}, a_{22},\\dots,a_{44}]
+\operatorname{row\_major}(A) = [a_{11}, a_{12}, a_{13}, a_{14},\; a_{21}, a_{22},\dots,a_{44}]
 $$
 
 - Column-major flattening (Fortran order) produces
 
 $$
-\\operatorname{col\\_major}(A) = [a_{11}, a_{21}, a_{31}, a_{41},\\; a_{12}, a_{22},\\dots,a_{44}]
+\operatorname{col\_major}(A) = [a_{11}, a_{21}, a_{31}, a_{41},\; a_{12}, a_{22},\dots,a_{44}]
 $$
 
 Why this matters for cuSolverMg
@@ -59,24 +59,24 @@ Avoiding the copy by matching sharding to column-major
 
 Example: split into two column-blocks
 
-Split $A$ into two column-blocks $B$ and $C$ (each $4\\times 2$):
+Split $A$ into two column-blocks $B$ and $C$ (each $4\times 2$):
 
 $$
-A = [\\; B \\;|\\; C \\;],\\quad
-B=\\begin{bmatrix} a_{11} & a_{12} \\\\
-a_{21} & a_{22} \\\\
-a_{31} & a_{32} \\\\
-a_{41} & a_{42}\\end{bmatrix},\\quad
-C=\\begin{bmatrix} a_{13} & a_{14} \\\\
-a_{23} & a_{24} \\\\
-a_{33} & a_{34} \\\\
-a_{43} & a_{44}\\end{bmatrix}
+A = [\; B \;|\; C \;],\quad
+B=\begin{bmatrix} a_{11} & a_{12} \\
+a_{21} & a_{22} \\
+a_{31} & a_{32} \\
+a_{41} & a_{42}\end{bmatrix},\quad
+C=\begin{bmatrix} a_{13} & a_{14} \\
+a_{23} & a_{24} \\
+a_{33} & a_{34} \\
+a_{43} & a_{44}\end{bmatrix}
 $$
 
 In column-major flattening, $B$ appears as a contiguous chunk followed by $C$:
 
 $$
-\\operatorname{col\\_major}(A) = [\\operatorname{col\\_major}(B),\\; \\operatorname{col\\_major}(C)].
+\operatorname{col\_major}(A) = [\operatorname{col\_major}(B),\; \operatorname{col\_major}(C)].
 $$
 
 If device 0 stores $B$ and device 1 stores $C$ in their native local buffers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,14 +30,20 @@ jaxmg = [
     "cu12/libpotrs.so",
     "cu12/libpotrs_mp.so",
     "cu12/libpotri.so",
+    "cu12/libpotri_mp.so",
     "cu12/libsyevd.so",
+    "cu12/libsyevd_mp.so",
     "cu12/libsyevd_no_V.so",
+    "cu12/libsyevd_no_V_mp.so",
     "cu13/libcyclic.so",
     "cu13/libpotrs.so",
     "cu13/libpotrs_mp.so",
     "cu13/libpotri.so",
+    "cu13/libpotri_mp.so",
     "cu13/libsyevd.so",
+    "cu13/libsyevd_mp.so",
     "cu13/libsyevd_no_V.so",
+    "cu13/libsyevd_no_V_mp.so",
 ]
 
 [project.optional-dependencies]

--- a/src/cuda/cyclic.cu
+++ b/src/cuda/cyclic.cu
@@ -130,9 +130,6 @@ namespace jax
                 batch_a = T_A;
             }
 
-            /* CUDA */
-            cudaDataType compute_type = traits<data_type>::cuda_data_type; // Data type for computation
-
             /* Shared memory */
             static std::once_flag barrier_initialized; // Initialize barrier once between threads
             std::call_once(barrier_initialized, [&]()

--- a/src/cuda/cyclic.cu
+++ b/src/cuda/cyclic.cu
@@ -130,14 +130,8 @@ namespace jax
                 batch_a = T_A;
             }
 
-            const int lda = N; // leading dimension of local A
             /* CUDA */
             cudaDataType compute_type = traits<data_type>::cuda_data_type; // Data type for computation
-
-            int info = 0;                     // Info used by cusolverMg calls
-            cusolverStatus_t cusolver_status; // Return status of cusolverMg calls
-            int64_t lwork_potrf = 0;          // Workspace size used by cusolverMg calls
-            int64_t lwork_potrs = 0;
 
             /* Shared memory */
             static std::once_flag barrier_initialized; // Initialize barrier once between threads

--- a/src/cuda/potri.cu
+++ b/src/cuda/potri.cu
@@ -128,7 +128,6 @@ namespace jax
             const int IA = 1; // index within a global matrix, base-1 (not used)
             const int JA = 1;
             const int T_A = std::min(tile_size, batch_a); // tile size of A
-            const int lda = N;                            // leading dimension of local A
 
             /* CUDA */
             cudaDataType compute_type = traits<data_type>::cuda_data_type;      // Data type for computation

--- a/src/cuda/potri_mp.cu
+++ b/src/cuda/potri_mp.cu
@@ -333,9 +333,17 @@ namespace jax
             {
                 if (currentDevice == 0)
                 {
+                    // Convert result from 1D block-cyclic layout back to
+                    // a single-device layout on device 0, then broadcast.
+                    memcpyCyclicShard<data_type>(nbGpus, stream, deviceList.data(),
+                                                 N, batch_a, T_A,
+                                                 /* input */
+                                                 shmA.data(), true);
+
+                    // Set out pointers inplace
                     for (int dev = 0; dev < nbGpus; dev++)
                     {
-                        JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(shmoutdata[dev], shmA[0], a.size_bytes(), gpuMemcpyDeviceToDevice));
+                        shmoutdata[dev]= shmA[dev];
                     }
                 }
             }

--- a/src/cuda/potri_mp.cu
+++ b/src/cuda/potri_mp.cu
@@ -99,10 +99,11 @@ namespace jax
     default:                                       \
         break;                                     \
     }
+
         template <typename data_type>
-        ffi::Error PotrsMgImpl(int64_t N, int64_t NRHS, int64_t batch_a,
+        ffi::Error PotriMgImpl(int64_t N, int64_t batch_a,
                                gpuStream_t stream, ffi::ScratchAllocator &scratch,
-                               ffi::AnyBuffer a, ffi::AnyBuffer b, int64_t tile_size,
+                               ffi::AnyBuffer a, int64_t tile_size,
                                ffi::Result<ffi::AnyBuffer> out, ffi::Result<ffi::Buffer<ffi::S32>> status)
         {
             /* misc */
@@ -114,8 +115,6 @@ namespace jax
             int currentDevice = 0;          // current GPU
             CUDA_CHECK_OR_RETURN(cudaGetDeviceCount(&nbGpus));
             CUDA_CHECK_OR_RETURN(cudaGetDevice(&currentDevice));
-            // std::printf("Number of GPUs: %d\n", nbGpus);
-            // std::printf("currentDevice: %d\n", currentDevice);
             if (nbGpus > MAX_NUM_DEVICES)
             {
                 return ffi::Error::InvalidArgument(
@@ -125,7 +124,6 @@ namespace jax
 
             /* data */
             auto array_data_A = static_cast<data_type *>(a.untyped_data()); // XLA device pointer for a
-            auto array_data_b = static_cast<data_type *>(b.untyped_data());
             auto out_data = static_cast<data_type *>(out->untyped_data());
 
             /* Tiling sizes */
@@ -133,33 +131,19 @@ namespace jax
             const int JA = 1;
             const int T_A = std::min(tile_size, batch_a); // tile size of A
 
-            const int IB = 1; // index within a global matrix, base-1 (not used)
-            const int JB = 1;
-
-            if (NRHS > 256)
-            {
-                return ffi::Error::InvalidArgument(
-                    absl::StrFormat("%s: Number of right hand sides must be <=256, received %d, "
-                                    "this may be improved in the next release",
-                                    source, NRHS));
-            }
-            const int T_B = static_cast<int>(NRHS); // tile size of B
-
             /* CUDA */
-            cudaDataType compute_type = traits<data_type>::cuda_data_type; // Data type for computation
-            cudaLibMgMatrixDesc_t descrA;                                  // CusolverMg matrix descriptors
-            cudaLibMgMatrixDesc_t descrB;
-            cudaLibMgGrid_t gridA; // CusolverMg grid descriptors
-            cudaLibMgGrid_t gridB;
+            cudaDataType compute_type = traits<data_type>::cuda_data_type;      // Data type for computation
+            cudaLibMgMatrixDesc_t descrA;                                       // CusolverMg matrix descriptors
+            cudaLibMgGrid_t gridA;                                              // CusolverMg grid descriptors
             cusolverMgGridMapping_t mapping = CUDALIBMG_GRID_MAPPING_COL_MAJOR; // Column major a la Scalapack
-            cusolverMgHandle_t cusolverH = nullptr;                             // = cusolverHPool.get();
+            cusolverMgHandle_t cusolverH = nullptr;                             // cusolver handle
             int info = 0;                                                       // Info used by cusolverMg calls
             cusolverStatus_t cusolver_status;                                   // Return status of cusolverMg calls
-            auto status_data = status->typed_data();                            // Status returned by potrf
+            auto status_data = status->typed_data();                            // Status returned by potri
             int64_t lwork_potrf = 0;                                            // Workspace size used by cusolverMg calls
-            int64_t lwork_potrs = 0;
+            int64_t lwork_potri = 0;
 
-            /* Shared memory */
+            /* Shared memory & barriers (multi-process) */
             const pid_t ppid = getppid();
             const std::string barrier_name = "/jaxmgbarrier_" + std::to_string(static_cast<long long>(ppid));
             DynamicBarrier sync_point(nbGpus, barrier_name.c_str());
@@ -168,8 +152,6 @@ namespace jax
 
             sharedMemoryInfo shminfoAipc;           // Shared memory info for device pointers to local matrices
             sharedMemoryInfo shminfo_offsetA;       // Shared memory info for offsets of A pointers
-            sharedMemoryInfo shminfoBipc;           // Shared memory info for device pointers to b matrices
-            sharedMemoryInfo shminfo_offsetB;       // Shared memory info for offsets of b pointers
             sharedMemoryInfo shminfooutdataipc;     // Shared memory info for device pointers to out matrices
             sharedMemoryInfo shminfo_offsetoutdata; // Shared memory info for offsets of out pointers
             sharedMemoryInfo shminfoworkipc;        // Shared memory info for workspace pointers
@@ -182,17 +164,14 @@ namespace jax
             IpcOpenResult<data_type> opened_ptrs_A;
             cudaIpcMemHandle_t *shmAipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoAipc, "shmAipc");
             uintptr_t *shmoffsetA = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetA, "shmoffsetA");
-            // Data handles b
-            std::vector<data_type *> shmB(nbGpus, nullptr);
-            IpcOpenResult<data_type> opened_ptrs_B;
-            cudaIpcMemHandle_t *shmBipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoBipc, "shmBipc");
-            uintptr_t *shmoffsetB = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetB, "shmoffsetB");
+
             // Data handles out_data
             std::vector<data_type *> shmoutdata(nbGpus, nullptr);
             IpcOpenResult<data_type> opened_ptrs_outdata;
             cudaIpcMemHandle_t *shmoutdataipc = get_shm_ipc_handles(currentDevice, sync_point, shminfooutdataipc, "shmoutdataipc");
             uintptr_t *shmoffsetoutdata = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetoutdata, "shmoffsetoutdata");
-            // Data handles shmwork
+
+            // Data handles workspace
             std::vector<data_type *> shmwork(nbGpus, nullptr);
             IpcOpenResult<data_type> opened_ptrs_work;
             cudaIpcMemHandle_t *shmworkipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoworkipc, "shmworkipc");
@@ -214,7 +193,6 @@ namespace jax
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDeviceSelect(cusolverH, nbGpus, deviceList.data()));
 
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgCreateDeviceGrid(&gridA, 1, nbGpus, deviceList.data(), mapping));
-                CUSOLVER_CHECK_OR_RETURN(cusolverMgCreateDeviceGrid(&gridB, 1, nbGpus, deviceList.data(), mapping));
 
                 /* (global) A is N-by-N */
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgCreateMatrixDesc(&descrA, N, /* number of rows of (global) A */
@@ -222,19 +200,12 @@ namespace jax
                                                                     N,          /* number or rows in a tile */
                                                                     T_A,        /* number of columns in a tile */
                                                                     compute_type, gridA));
-
-                /* (global) B is N-by-NRHS */
-                CUSOLVER_CHECK_OR_RETURN(cusolverMgCreateMatrixDesc(&descrB, N, /* number of rows of (global) B */
-                                                                    NRHS,       /* number of columns of (global) B */
-                                                                    N,          /* number or rows in a tile */
-                                                                    T_B,        /* number of columns in a tile */
-                                                                    compute_type, gridB));
             }
 
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
+            // Export device pointers and offsets via CUDA IPC
             ipcGetHandleAndOffset(array_data_A, shmAipc[currentDevice], shmoffsetA[currentDevice]);
-            ipcGetHandleAndOffset(array_data_b, shmBipc[currentDevice], shmoffsetB[currentDevice]);
             ipcGetHandleAndOffset(out_data, shmoutdataipc[currentDevice], shmoffsetoutdata[currentDevice]);
 
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
@@ -244,17 +215,14 @@ namespace jax
             if (currentDevice == 0)
             {
                 opened_ptrs_A = ipcGetDevicePointers<data_type>(currentDevice, nbGpus, shmAipc, shmoffsetA);
-                opened_ptrs_B = ipcGetDevicePointers<data_type>(currentDevice, nbGpus, shmBipc, shmoffsetB);
                 opened_ptrs_outdata = ipcGetDevicePointers<data_type>(currentDevice, nbGpus, shmoutdataipc, shmoffsetoutdata);
 
                 for (int dev = 1; dev < nbGpus; ++dev)
                 {
                     shmA[dev] = opened_ptrs_A.ptrs[dev];
-                    shmB[dev] = opened_ptrs_B.ptrs[dev];
                     shmoutdata[dev] = opened_ptrs_outdata.ptrs[dev];
                 }
                 shmA[0] = array_data_A;
-                shmB[0] = array_data_b;
                 shmoutdata[0] = out_data;
             }
 
@@ -274,22 +242,19 @@ namespace jax
             if (currentDevice == 0)
             {
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgPotrf_bufferSize(cusolverH, CUBLAS_FILL_MODE_LOWER, N,
-                                                                    //   reinterpret_cast<void **>(array_d_A.data()), IA, /* base-1 */
                                                                     reinterpret_cast<void **>(shmA.data()), IA, /* base-1 */
                                                                     JA,                                         /* base-1 */
                                                                     descrA, compute_type, &lwork_potrf));
-                CUSOLVER_CHECK_OR_RETURN(cusolverMgPotrs_bufferSize(cusolverH, CUBLAS_FILL_MODE_LOWER, N, NRHS, /* NRHS */
-                                                                                                                //   reinterpret_cast<void **>(array_d_A.data()), IA, JA,
-                                                                    reinterpret_cast<void **>(shmA.data()), IA, JA,
-                                                                    //   descrA, reinterpret_cast<void **>(array_d_B.data()),
-                                                                    descrA, reinterpret_cast<void **>(shmB.data()),
-                                                                    IB, JB, descrB, compute_type,
-                                                                    &lwork_potrs));
+
+                CUSOLVER_CHECK_OR_RETURN(cusolverMgPotri_bufferSize(cusolverH, CUBLAS_FILL_MODE_LOWER, N,
+                                                                    reinterpret_cast<void **>(shmA.data()), IA, JA, descrA,
+                                                                    compute_type,
+                                                                    &lwork_potri));
 
                 for (int dev = 0; dev < nbGpus; ++dev)
                 {
-                    shmlwork[dev] = std::max(lwork_potrf, lwork_potrs);
-                };
+                    shmlwork[dev] = std::max(lwork_potrf, lwork_potri);
+                }
             }
 
             sync_point.arrive_and_wait();
@@ -300,14 +265,13 @@ namespace jax
             sync_point.arrive_and_wait();
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
 
-            // Get all workspace pointers on rank 0.
+            // Allocate workspace pointers on rank 0 and share via IPC
             if (currentDevice == 0)
             {
                 workspaceAlloc(nbGpus, deviceList.data(),
                                workspace_bytes, /* number of bytes per device */
                                reinterpret_cast<void **>(shmwork.data()));
             }
-            // /* sync all devices */
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
 
@@ -326,19 +290,17 @@ namespace jax
                 {
                     cusolver_status_host[dev] = static_cast<int32_t>(cusolver_status);
                 }
-                /* check if A is singular */
+                /* check if A is valid */
                 if (0 > info)
                 {
                     return ffi::Error::Internal(
                         absl::StrFormat("unexpected error in cusolverMgPotrf, %d-th input parameter is wrong \n", -info));
                 }
 
-                // Check status, if 0, continue with Potrs
                 if (cusolver_status_host[0] == 0)
                 {
-                    cusolver_status = cusolverMgPotrs(cusolverH, CUBLAS_FILL_MODE_LOWER, N, NRHS, /* NRHS */
+                    cusolver_status = cusolverMgPotri(cusolverH, CUBLAS_FILL_MODE_LOWER, N,
                                                       reinterpret_cast<void **>(shmA.data()), IA, JA, descrA,
-                                                      reinterpret_cast<void **>(shmB.data()), IB, JB, descrB,
                                                       compute_type,
                                                       reinterpret_cast<void **>(shmwork.data()), shmlwork[currentDevice],
                                                       &info);
@@ -353,7 +315,7 @@ namespace jax
                     if (0 > info)
                     {
                         return ffi::Error::Internal(
-                            absl::StrFormat("unexpected error in cusolverMgPotrs, %d-th input parameter is wrong \n", -info));
+                            absl::StrFormat("unexpected error in cusolverMgPotri, %d-th input parameter is wrong \n", -info));
                     }
                 }
             }
@@ -362,48 +324,39 @@ namespace jax
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
 
-            if (currentDevice == 0)
-            {
-                std::vector<typename traits<data_type>::T> host_out(N);
-                size_t numBytes = sizeof(data_type) * N;
-                CUDA_CHECK_OR_RETURN(cudaMemcpy(host_out.data(), shmB[0], numBytes, cudaMemcpyDeviceToHost));
-                CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
-            }
             // Write status data
             int32_t status_val = static_cast<int32_t>(cusolver_status_host[currentDevice]);
             JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(status_data, &status_val, sizeof(status_val), gpuMemcpyHostToDevice));
-            // Write solution to all shmBs
-            if (currentDevice == 0)
+
+            // Broadcast result or fill NaNs on failure
+            if (cusolver_status_host[currentDevice] == 0)
             {
-                for (int dev = 0; dev < nbGpus; dev++)
+                if (currentDevice == 0)
                 {
-                    JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(shmoutdata[dev], shmB[0], b.size_bytes(), gpuMemcpyDeviceToDevice));
+                    for (int dev = 0; dev < nbGpus; dev++)
+                    {
+                        JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(shmoutdata[dev], shmA[0], a.size_bytes(), gpuMemcpyDeviceToDevice));
+                    }
                 }
             }
-            CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
-            sync_point.arrive_and_wait();
-            // Fill nans if solver failed
-            if (cusolver_status_host[currentDevice] != 0)
+            else
             {
-                std::vector<typename traits<data_type>::T> host_nan(N * NRHS, traits<data_type>::nan());
-                JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(out_data, host_nan.data(), sizeof(data_type) * N * NRHS, gpuMemcpyHostToDevice));
+                std::vector<typename traits<data_type>::T> host_nan(N * batch_a, traits<data_type>::nan());
+                JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(out_data, host_nan.data(), sizeof(data_type) * N * batch_a, gpuMemcpyHostToDevice));
             }
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
+
             if (currentDevice == 0)
             {
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyMatrixDesc(descrA));
-                CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyMatrixDesc(descrB));
 
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyGrid(gridA));
-                CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyGrid(gridB));
 
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroy(cusolverH));
                 // Shared memory close
                 sharedMemoryCleanup(&shminfo_offsetA, "shmoffsetA");
                 sharedMemoryCleanup(&shminfoAipc, "shmAipc");
-                sharedMemoryCleanup(&shminfo_offsetB, "shmoffsetB");
-                sharedMemoryCleanup(&shminfoBipc, "shmBipc");
                 sharedMemoryCleanup(&shminfo_offsetoutdata, "shmoffsetoutdata");
                 sharedMemoryCleanup(&shminfooutdataipc, "shmoutdataipc");
                 sharedMemoryCleanup(&shminfoworkipc, "shmworkipc");
@@ -412,53 +365,44 @@ namespace jax
                 sharedMemoryCleanup(&shminfo_csh, "shmcsh");
                 // Close memory handles
                 ipcCloseDevicePointers(currentDevice, opened_ptrs_A.bases, nbGpus);
-                ipcCloseDevicePointers(currentDevice, opened_ptrs_B.bases, nbGpus);
                 ipcCloseDevicePointers(currentDevice, opened_ptrs_outdata.bases, nbGpus);
                 workspaceFree(nbGpus, deviceList.data(), reinterpret_cast<void **>(shmwork.data()));
             }
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.close_and_wait();
-            
+
             return ffi::Error::Success();
         }
 
-        ffi::Error PotrsMgDispatch(gpuStream_t stream, ffi::ScratchAllocator scratch,
-                                   ffi::AnyBuffer a, ffi::AnyBuffer b, int64_t tile_size,
-                                   ffi::Result<ffi::AnyBuffer> out, ffi::Result<ffi::Buffer<ffi::S32>> status)
+        ffi::Error PotriMgMpDispatch(gpuStream_t stream, ffi::ScratchAllocator scratch,
+                                     ffi::AnyBuffer a, int64_t tile_size,
+                                     ffi::Result<ffi::AnyBuffer> out, ffi::Result<ffi::Buffer<ffi::S32>> status)
         {
             auto dataType = a.element_type();
 
             // Rows are batched
             FFI_ASSIGN_OR_RETURN((const auto [batch_a, N]), SplitBatch1D(a.dimensions()));
-            FFI_ASSIGN_OR_RETURN((const auto [N_b, NRHS]), SplitBatch1D(b.dimensions()));
-            FFI_RETURN_IF_ERROR(CheckShape(b.dimensions(), {N, NRHS}, "b", "potrf"));
 
             if (dataType != out->element_type())
             {
                 return ffi::Error::InvalidArgument(
-                    "The input and output to potrs must have the same element type");
+                    "The input matrix a and output inverse matrix of potri must have the same element type");
             }
-            if (dataType != b.element_type())
-            {
-                return ffi::Error::InvalidArgument(
-                    "The input matrix a and output x of potrs must have the same element type");
-            }
-            FFI_RETURN_IF_ERROR(CheckShape(status->dimensions(), 1, "status", "potrf"));
+            FFI_RETURN_IF_ERROR(CheckShape(status->dimensions(), 1, "status", "potri"));
 
-            SOLVER_DISPATCH_IMPL(PotrsMgImpl, N, NRHS, batch_a, stream, scratch, a, b, tile_size, out, status);
+            SOLVER_DISPATCH_IMPL(PotriMgImpl, N, batch_a, stream, scratch, a, tile_size, out, status);
 
             return ffi::Error::InvalidArgument(absl::StrFormat(
-                "Unsupported data type%s for potrs", absl::FormatStreamed(dataType)));
+                "Unsupported data type%s for potri", absl::FormatStreamed(dataType)));
         }
 
-        XLA_FFI_DEFINE_HANDLER_SYMBOL(PotrsMgMpFFI, PotrsMgDispatch,
+        XLA_FFI_DEFINE_HANDLER_SYMBOL(PotriMgMpFFI, PotriMgMpDispatch,
                                       ffi::Ffi::Bind()
                                           .Ctx<ffi::PlatformStream<gpuStream_t>>()
                                           .Ctx<ffi::ScratchAllocator>()
                                           .Arg<ffi::AnyBuffer>()        // A
-                                          .Arg<ffi::AnyBuffer>()        // b
                                           .Attr<int64_t>("T_A")         // tile size
-                                          .Ret<ffi::AnyBuffer>()        // x
+                                          .Ret<ffi::AnyBuffer>()        // out
                                           .Ret<ffi::Buffer<ffi::S32>>() // status
         );
 

--- a/src/cuda/potrs.cu
+++ b/src/cuda/potrs.cu
@@ -185,7 +185,6 @@ namespace jax
                     deviceList[j] = j;
                     cudaDeviceProp prop;
                     CUDA_CHECK_OR_RETURN(cudaGetDeviceProperties(&prop, j));
-                    enablePeerAccess(nbGpus, deviceList.data());
                 }
 
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDeviceSelect(cusolverH, nbGpus, deviceList.data()));

--- a/src/cuda/potrs.cu
+++ b/src/cuda/potrs.cu
@@ -129,7 +129,6 @@ namespace jax
             const int IA = 1; // index within a global matrix, base-1 (not used)
             const int JA = 1;
             const int T_A = std::min(tile_size, batch_a); // tile size of A
-            const int lda = N;                            // leading dimension of local A
 
             const int IB = 1; // index within a global matrix, base-1 (not used)
             const int JB = 1;
@@ -142,7 +141,6 @@ namespace jax
                                     source, NRHS));
             }
             const int T_B = static_cast<int>(NRHS); // tile size of B
-            const int ldb = N;                      // leading dimension of local b
 
             /* CUDA */
             cudaDataType compute_type = traits<data_type>::cuda_data_type; // Data type for computation
@@ -187,6 +185,7 @@ namespace jax
                     deviceList[j] = j;
                     cudaDeviceProp prop;
                     CUDA_CHECK_OR_RETURN(cudaGetDeviceProperties(&prop, j));
+                    enablePeerAccess(nbGpus, deviceList.data());
                 }
 
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDeviceSelect(cusolverH, nbGpus, deviceList.data()));

--- a/src/cuda/potrs_mp.cu
+++ b/src/cuda/potrs_mp.cu
@@ -132,7 +132,6 @@ namespace jax
             const int IA = 1; // index within a global matrix, base-1 (not used)
             const int JA = 1;
             const int T_A = std::min(tile_size, batch_a); // tile size of A
-            const int lda = N;                            // leading dimension of local A
 
             const int IB = 1; // index within a global matrix, base-1 (not used)
             const int JB = 1;
@@ -145,7 +144,6 @@ namespace jax
                                     source, NRHS));
             }
             const int T_B = static_cast<int>(NRHS); // tile size of B
-            const int ldb = N;                      // leading dimension of local b
 
             /* CUDA */
             cudaDataType compute_type = traits<data_type>::cuda_data_type; // Data type for computation
@@ -238,7 +236,6 @@ namespace jax
 
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
-
             ipcGetHandleAndOffset(array_data_A, shmAipc[currentDevice], shmoffsetA[currentDevice]);
             ipcGetHandleAndOffset(array_data_b, shmBipc[currentDevice], shmoffsetB[currentDevice]);
             ipcGetHandleAndOffset(out_data, shmoutdataipc[currentDevice], shmoffsetoutdata[currentDevice]);
@@ -282,7 +279,6 @@ namespace jax
                                              /* input */
                                              shmA.data(), false);
             }
-
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
 
@@ -308,7 +304,6 @@ namespace jax
             }
 
             sync_point.arrive_and_wait();
-
             // Assign workspace
             size_t workspace_bytes = sizeof(data_type) * static_cast<size_t>(shmlwork[currentDevice]);
 
@@ -322,7 +317,6 @@ namespace jax
                                workspace_bytes, /* number of bytes per device */
                                reinterpret_cast<void **>(shmwork.data()));
             }
-
             // /* sync all devices */
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
@@ -359,7 +353,6 @@ namespace jax
                                                       &info);
                     /* sync all devices */
                     CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
-
                     for (int dev = 0; dev < nbGpus; dev++)
                     {
                         cusolver_status_host[dev] = static_cast<int32_t>(cusolver_status);
@@ -432,8 +425,7 @@ namespace jax
                 workspaceFree(nbGpus, deviceList.data(), reinterpret_cast<void **>(shmwork.data()));
             }
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
-            sync_point.arrive_and_wait();
-
+            sync_point.close_and_wait();
             return ffi::Error::Success();
         }
 

--- a/src/cuda/syevd.cu
+++ b/src/cuda/syevd.cu
@@ -132,7 +132,6 @@ namespace jax
             const int IA = 1; // index within a global matrix, base-1 (not used)
             const int JA = 1;
             const int T_A = std::min(tile_size, batch_a); // tile size of A
-            const int lda = N;                            // leading dimension of local A
 
             /* CUDA */
             cudaDataType compute_type = traits<data_type>::cuda_data_type;                        // Data type for computation

--- a/src/cuda/syevd_mp.cu
+++ b/src/cuda/syevd_mp.cu
@@ -344,10 +344,10 @@ namespace jax
                                                  /* input */
                                                  shmA.data(), true);
                     // After unsharding, shmA[0] should contain the full matrix in device 0 layout.
-                    // Broadcast to all V outputs
+                    // Set out pointers inplace
                     for (int dev = 0; dev < nbGpus; dev++)
                     {
-                        JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(shmV[dev], shmA[0], a.size_bytes(), gpuMemcpyDeviceToDevice));
+                        shmV[dev]= shmA[dev];
                     }
                 }
             }

--- a/src/cuda/syevd_mp.cu
+++ b/src/cuda/syevd_mp.cu
@@ -66,17 +66,18 @@
 #include "jaxlib/gpu/vendor.h"
 // XLA
 #include "xla/ffi/api/ffi.h"
+#include "xla/ffi/api/c_api.h"
 // CUDA
 #include "third_party/gpus/cuda/include/cusolverMg.h"
 #include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "third_party/gpus/cuda/include/cuda_runtime.h"
+#include "third_party/gpus/cuda/include/cuda.h"
 // My Code
 #include "utils/jax_utils.h"
 #include "cusolver_utils.h"
-#include "thread_barrier.h"
+#include "process_barrier.h"
 #include "utils/shm.h"
-
-ThreadBarrier sync_point;
+#include "utils/ipc_utils.h"
 
 namespace jax
 {
@@ -98,21 +99,22 @@ namespace jax
     default:                                       \
         break;                                     \
     }
+
         template <typename data_type>
-        ffi::Error SyevdMgImpl(int64_t N, int64_t batch_a,
-                               gpuStream_t stream, ffi::ScratchAllocator &scratch,
-                               ffi::AnyBuffer a, int64_t tile_size,
-                               ffi::Result<ffi::AnyBuffer> eigenvalues,
-                               ffi::Result<ffi::AnyBuffer> V,
-                               ffi::Result<ffi::Buffer<ffi::S32>> status)
+        ffi::Error SyevdMgImplMp(int64_t N, int64_t batch_a,
+                                 gpuStream_t stream, ffi::ScratchAllocator &scratch,
+                                 ffi::AnyBuffer a, int64_t tile_size,
+                                 ffi::Result<ffi::AnyBuffer> eigenvalues,
+                                 ffi::Result<ffi::AnyBuffer> V,
+                                 ffi::Result<ffi::Buffer<ffi::S32>> status)
         {
             /* misc */
-            const std::string &source = __FILE__; // file name for error messages
+            const std::string &source = __FILE__;
 
             /* GPU */
-            const int MAX_NUM_DEVICES = 16; // cusolverMg can handle 16 GPUs at most
-            int nbGpus = 0;                 // number of GPUs to use
-            int currentDevice = 0;          // current GPU
+            const int MAX_NUM_DEVICES = 16;
+            int nbGpus = 0;
+            int currentDevice = 0;
             CUDA_CHECK_OR_RETURN(cudaGetDeviceCount(&nbGpus));
             CUDA_CHECK_OR_RETURN(cudaGetDevice(&currentDevice));
             if (nbGpus > MAX_NUM_DEVICES)
@@ -120,55 +122,80 @@ namespace jax
                 return ffi::Error::InvalidArgument(
                     absl::StrFormat("%s: Number of Gpus must be <=16, received %d", source, nbGpus));
             }
-            std::vector<int> deviceList(nbGpus); // list of device IDs
+            std::vector<int> deviceList(nbGpus);
 
             /* data */
-            auto array_data_A = static_cast<data_type *>(a.untyped_data()); // XLA device pointer for a
+            auto array_data_A = static_cast<data_type *>(a.untyped_data());
             auto array_data_eigenvalues = static_cast<data_type *>(eigenvalues->untyped_data());
             auto array_data_V = static_cast<data_type *>(V->untyped_data());
-            std::vector<typename traits<data_type>::S> eigenvalues_host(N, 0.); // Make vector of Real datatype
+            std::vector<typename traits<data_type>::S> eigenvalues_host(N, 0.);
 
             /* Tiling sizes */
-            const int IA = 1; // index within a global matrix, base-1 (not used)
+            const int IA = 1;
             const int JA = 1;
-            const int T_A = std::min(tile_size, batch_a); // tile size of A
+            const int T_A = std::min(tile_size, batch_a);
 
             /* CUDA */
-            cudaDataType compute_type = traits<data_type>::cuda_data_type;                        // Data type for computation
-            cudaDataType eigenvalue_type = traits<typename traits<data_type>::S>::cuda_data_type; // Real data type used
-            cudaLibMgMatrixDesc_t descrA;                                                         // CusolverMg matrix descriptors
-            cudaLibMgGrid_t gridA;                                                                // CusolverMg grid descriptors
-            cusolverMgGridMapping_t mapping = CUDALIBMG_GRID_MAPPING_COL_MAJOR;                   // Column major a la Scalapack
-            cusolverEigMode_t jobz = CUSOLVER_EIG_MODE_VECTOR;                                    // Wether to return both eigenvectors and eigenvalues
-            FFI_ASSIGN_OR_RETURN(auto cusolverHPool, SolverHandlePool::Borrow(stream));           // Assign a cusolver handle from the pool
-            cusolverMgHandle_t cusolverH = nullptr;                                               // cusolverHPool.get();
-            int info = 0;                                                                         // Info used by cusolverMg calls
-            cusolverStatus_t cusolver_status;                                                     // Return status of cusolverMg calls
-            auto status_data = status->typed_data();                                              // Status returned by syevd
-            int64_t lwork_syevd = 0;                                                              // Workspace size used by cusolverMg calls
+            cudaDataType compute_type = traits<data_type>::cuda_data_type;
+            cudaDataType eigenvalue_type = traits<typename traits<data_type>::S>::cuda_data_type;
+            cudaLibMgMatrixDesc_t descrA;
+            cudaLibMgGrid_t gridA;
+            cusolverMgGridMapping_t mapping = CUDALIBMG_GRID_MAPPING_COL_MAJOR;
+            cusolverEigMode_t jobz = CUSOLVER_EIG_MODE_VECTOR;
+            cusolverMgHandle_t cusolverH = nullptr;
+            int info = 0;
+            cusolverStatus_t cusolver_status;
+            auto status_data = status->typed_data();
+            int64_t lwork_syevd = 0;
 
-            /* Shared memory */
-            static std::once_flag barrier_initialized; // Initialize barrier once between threads
-            std::call_once(barrier_initialized, [&]()
-                           { sync_point.initialize(nbGpus); });
+            /* Shared memory (multi-process barrier) */
+            const pid_t ppid = getppid();
+            const std::string barrier_name = "/jaxmgbarrier_" + std::to_string(static_cast<long long>(ppid));
+            DynamicBarrier sync_point(nbGpus, barrier_name.c_str());
             sync_point.arrive_and_wait();
-            sharedMemoryInfo shminfoA;  // Shared memory info for device pointers to local matrices
-            sharedMemoryInfo shminfoev; // Shared memory info for device pointers to local matrices
-            sharedMemoryInfo shminfowork;
-            sharedMemoryInfo shminfolwork; // Shared memory info for lwork space nbytes
-            sharedMemoryInfo shmcsh;       // Shared memory info for cusolver status
+            CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
 
-            data_type **shmA = get_shm_device_ptrs<data_type>(currentDevice, sync_point, shminfoA, "shmA");    // Actual shared memory
-            data_type **shmev = get_shm_device_ptrs<data_type>(currentDevice, sync_point, shminfoev, "shmev"); // Actual shared memory
-            data_type **shmwork = get_shm_device_ptrs<data_type>(currentDevice, sync_point, shminfowork, "shmwork");
+            sharedMemoryInfo shminfoAipc;        // Shared memory info for device pointers to local matrices A
+            sharedMemoryInfo shminfo_offsetA;    // Shared memory info for offsets of A pointers
+            sharedMemoryInfo shminfoevipc;       // Shared memory info for device pointers to eigenvalue arrays
+            sharedMemoryInfo shminfo_offsetev;   // Shared memory info for offsets of eigenvalue pointers
+            sharedMemoryInfo shminfoVipc;        // Shared memory info for device pointers to eigenvector matrices
+            sharedMemoryInfo shminfo_offsetV;    // Shared memory info for offsets of eigenvector pointers
+            sharedMemoryInfo shminfoworkipc;     // Shared memory info for workspace pointers
+            sharedMemoryInfo shminfo_offsetwork; // Shared memory info for offsets of workspace pointers
+            sharedMemoryInfo shminfolwork;       // Shared memory info for lwork
+            sharedMemoryInfo shminfo_csh;        // Shared memory info for cusolver status
 
-            int32_t *cusolver_status_host = get_shm_lwork_ptr<int32_t, ThreadBarrier>(currentDevice, sync_point, shmcsh, "shmcsh");
-            int64_t *shmlwork = get_shm_lwork_ptr<int64_t, ThreadBarrier>(currentDevice, sync_point, shminfolwork, "shmlwork");
+            // Data handles A
+            std::vector<data_type *> shmA(nbGpus, nullptr);
+            IpcOpenResult<data_type> opened_ptrs_A;
+            cudaIpcMemHandle_t *shmAipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoAipc, "shmAipc");
+            uintptr_t *shmoffsetA = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetA, "shmoffsetA");
+
+            // Data handles eigenvalues
+            std::vector<data_type *> shmev(nbGpus, nullptr);
+            IpcOpenResult<data_type> opened_ptrs_ev;
+            cudaIpcMemHandle_t *shmevipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoevipc, "shmevipc");
+            uintptr_t *shmoffsetev = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetev, "shmoffsetev");
+
+            // Data handles V (eigenvectors)
+            std::vector<data_type *> shmV(nbGpus, nullptr);
+            IpcOpenResult<data_type> opened_ptrs_V;
+            cudaIpcMemHandle_t *shmVipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoVipc, "shmVipc");
+            uintptr_t *shmoffsetV = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetV, "shmoffsetV");
+
+            // Workspace
+            std::vector<data_type *> shmwork(nbGpus, nullptr);
+            IpcOpenResult<data_type> opened_ptrs_work;
+            cudaIpcMemHandle_t *shmworkipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoworkipc, "shmworkipc");
+            uintptr_t *shmoffsetwork = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetwork, "shmoffsetwork");
+
+            int32_t *cusolver_status_host = get_shm_lwork_ptr<int32_t>(currentDevice, sync_point, shminfo_csh, "shmcsh");
+            int64_t *shmlwork = get_shm_lwork_ptr<int64_t>(currentDevice, sync_point, shminfolwork, "shmlwork");
 
             if (currentDevice == 0)
             {
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgCreate(&cusolverH));
-
                 for (int j = 0; j < nbGpus; j++)
                 {
                     deviceList[j] = j;
@@ -177,35 +204,61 @@ namespace jax
                 }
 
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDeviceSelect(cusolverH, nbGpus, deviceList.data()));
-
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgCreateDeviceGrid(&gridA, 1, nbGpus, deviceList.data(), mapping));
 
-                /* (global) A is N-by-N */
-                CUSOLVER_CHECK_OR_RETURN(cusolverMgCreateMatrixDesc(&descrA, N, /* number of rows of (global) A */
-                                                                    N,          /* number of columns of (global) A */
-                                                                    N,          /* number or rows in a tile */
-                                                                    T_A,        /* number of columns in a tile */
+                CUSOLVER_CHECK_OR_RETURN(cusolverMgCreateMatrixDesc(&descrA, N,
+                                                                    N,
+                                                                    N,
+                                                                    T_A,
                                                                     compute_type, gridA));
             }
 
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
-            shmA[currentDevice] = array_data_A;
             sync_point.arrive_and_wait();
+
+            // Export local device pointers via CUDA IPC
+            ipcGetHandleAndOffset(array_data_A, shmAipc[currentDevice], shmoffsetA[currentDevice]);
+            ipcGetHandleAndOffset(array_data_eigenvalues, shmevipc[currentDevice], shmoffsetev[currentDevice]);
+            ipcGetHandleAndOffset(array_data_V, shmVipc[currentDevice], shmoffsetV[currentDevice]);
+
+            CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
+            sync_point.arrive_and_wait();
+
             if (currentDevice == 0)
             {
+                opened_ptrs_A = ipcGetDevicePointers<data_type>(currentDevice, nbGpus, shmAipc, shmoffsetA);
+                opened_ptrs_ev = ipcGetDevicePointers<data_type>(currentDevice, nbGpus, shmevipc, shmoffsetev);
+                opened_ptrs_V = ipcGetDevicePointers<data_type>(currentDevice, nbGpus, shmVipc, shmoffsetV);
+
+                for (int dev = 1; dev < nbGpus; ++dev)
+                {
+                    shmA[dev] = opened_ptrs_A.ptrs[dev];
+                    shmev[dev] = opened_ptrs_ev.ptrs[dev];
+                    shmV[dev] = opened_ptrs_V.ptrs[dev];
+                }
+                shmA[0] = array_data_A;
+                shmev[0] = array_data_eigenvalues;
+                shmV[0] = array_data_V;
+            }
+
+            CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
+            sync_point.arrive_and_wait();
+
+            if (currentDevice == 0)
+            {
+                // Convert input layout to 1D block-cyclic layout across devices
                 memcpyCyclicShard<data_type>(nbGpus, stream, deviceList.data(),
                                              N, batch_a, T_A,
                                              /* input */
-                                             shmA, false);
+                                             shmA.data(), false);
             }
-
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
 
             if (currentDevice == 0)
             {
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgSyevd_bufferSize(cusolverH, jobz, CUBLAS_FILL_MODE_LOWER, N,
-                                                                    reinterpret_cast<void **>(shmA), IA, JA, descrA,
+                                                                    reinterpret_cast<void **>(shmA.data()), IA, JA, descrA,
                                                                     reinterpret_cast<void *>(eigenvalues_host.data()),
                                                                     eigenvalue_type, compute_type,
                                                                     &lwork_syevd));
@@ -215,15 +268,22 @@ namespace jax
                     shmlwork[dev] = lwork_syevd;
                 }
             }
+
             sync_point.arrive_and_wait();
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
 
-            /* array_d_work[j] points to device workspace of device j */
-            FFI_ASSIGN_OR_RETURN(auto workspace, AllocateWorkspaceBytes<data_type>(scratch, sizeof(data_type) * (shmlwork[currentDevice]), "workspace_syevd"));
-            shmwork[currentDevice] = workspace;
-            shmev[currentDevice] = array_data_eigenvalues;
+            // Workspace size in bytes for current device
+            size_t workspace_bytes = sizeof(data_type) * static_cast<size_t>(shmlwork[currentDevice]);
 
-            /* sync all devices */
+            sync_point.arrive_and_wait();
+            CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
+
+            if (currentDevice == 0)
+            {
+                workspaceAlloc(nbGpus, deviceList.data(),
+                               workspace_bytes,
+                               reinterpret_cast<void **>(shmwork.data()));
+            }
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
 
@@ -231,41 +291,40 @@ namespace jax
             {
                 cusolver_status = cusolverMgSyevd(
                     cusolverH, jobz, CUBLAS_FILL_MODE_LOWER, N,
-                    reinterpret_cast<void **>(shmA), IA, JA,
+                    reinterpret_cast<void **>(shmA.data()), IA, JA,
                     descrA, reinterpret_cast<void **>(eigenvalues_host.data()),
                     eigenvalue_type, compute_type,
-                    reinterpret_cast<void **>(shmwork), *shmlwork, &info);
+                    reinterpret_cast<void **>(shmwork.data()), shmlwork[currentDevice], &info);
 
-                /* sync all devices */
                 CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
-                // Copy status to all devices
                 for (int dev = 0; dev < nbGpus; dev++)
                 {
                     cusolver_status_host[dev] = static_cast<int32_t>(cusolver_status);
                 }
-                /* check if A is singular */
+
                 if (0 > info)
                 {
                     return ffi::Error::Internal(
                         absl::StrFormat("unexpected error in cusolverMgSyevd, %d-th input parameter is wrong \n", -info));
                 }
             }
-            /* sync all devices */
+
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
 
-            // Write status data
+            // Write status per device
             int32_t status_val = static_cast<int32_t>(cusolver_status_host[currentDevice]);
             JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(status_data, &status_val, sizeof(status_val), gpuMemcpyHostToDevice));
 
             if (currentDevice == 0)
             {
                 if (cusolver_status_host[0] == 0)
-                { // Copy solution to device 0
+                {
+                    // Copy eigenvalues to device 0 eigenvalue buffer
                     JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(
                         shmev[0], eigenvalues_host.data(), sizeof(data_type) * N, gpuMemcpyHostToDevice));
                     CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
-                    // Copy solution to all other devices
+                    // Broadcast eigenvalues to all other devices
                     for (int dev = 1; dev < nbGpus; dev++)
                     {
                         JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(shmev[dev], shmev[0], sizeof(data_type) * N, gpuMemcpyDeviceToDevice));
@@ -278,13 +337,18 @@ namespace jax
             if (cusolver_status_host[currentDevice] == 0)
             {
                 // Unshard eigenvectors from shmA back into V buffers
-                array_data_V = shmA[currentDevice];
                 if (currentDevice == 0)
                 {
                     memcpyCyclicShard<data_type>(nbGpus, stream, deviceList.data(),
                                                  N, batch_a, T_A,
                                                  /* input */
-                                                 shmA, true);
+                                                 shmA.data(), true);
+                    // After unsharding, shmA[0] should contain the full matrix in device 0 layout.
+                    // Broadcast to all V outputs
+                    for (int dev = 0; dev < nbGpus; dev++)
+                    {
+                        JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(shmV[dev], shmA[0], a.size_bytes(), gpuMemcpyDeviceToDevice));
+                    }
                 }
             }
             else
@@ -300,28 +364,36 @@ namespace jax
             if (currentDevice == 0)
             {
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyMatrixDesc(descrA));
-
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyGrid(gridA));
-
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroy(cusolverH));
 
-                sharedMemoryCleanup(&shminfoA, "shmA");
-                sharedMemoryCleanup(&shminfoev, "shmev");
-                sharedMemoryCleanup(&shminfowork, "shmwork");
-                sharedMemoryCleanup(&shmcsh, "shmcsh");
+                sharedMemoryCleanup(&shminfo_offsetA, "shmoffsetA");
+                sharedMemoryCleanup(&shminfoAipc, "shmAipc");
+                sharedMemoryCleanup(&shminfo_offsetev, "shmoffsetev");
+                sharedMemoryCleanup(&shminfoevipc, "shmevipc");
+                sharedMemoryCleanup(&shminfo_offsetV, "shmoffsetV");
+                sharedMemoryCleanup(&shminfoVipc, "shmVipc");
+                sharedMemoryCleanup(&shminfoworkipc, "shmworkipc");
+                sharedMemoryCleanup(&shminfo_offsetwork, "shmoffsetwork");
                 sharedMemoryCleanup(&shminfolwork, "shmlwork");
+                sharedMemoryCleanup(&shminfo_csh, "shmcsh");
+
+                ipcCloseDevicePointers(currentDevice, opened_ptrs_A.bases, nbGpus);
+                ipcCloseDevicePointers(currentDevice, opened_ptrs_ev.bases, nbGpus);
+                ipcCloseDevicePointers(currentDevice, opened_ptrs_V.bases, nbGpus);
+                workspaceFree(nbGpus, deviceList.data(), reinterpret_cast<void **>(shmwork.data()));
             }
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
-            sync_point.arrive_and_wait();
+            sync_point.close_and_wait();
 
             return ffi::Error::Success();
         }
 
-        ffi::Error SyevdMgDispatch(gpuStream_t stream, ffi::ScratchAllocator scratch,
-                                   ffi::AnyBuffer a, int64_t tile_size,
-                                   ffi::Result<ffi::AnyBuffer> eigenvalues,
-                                   ffi::Result<ffi::AnyBuffer> V,
-                                   ffi::Result<ffi::Buffer<ffi::S32>> status)
+        ffi::Error SyevdMgMpDispatch(gpuStream_t stream, ffi::ScratchAllocator scratch,
+                                     ffi::AnyBuffer a, int64_t tile_size,
+                                     ffi::Result<ffi::AnyBuffer> eigenvalues,
+                                     ffi::Result<ffi::AnyBuffer> V,
+                                     ffi::Result<ffi::Buffer<ffi::S32>> status)
         {
             auto dataType = a.element_type();
 
@@ -335,13 +407,13 @@ namespace jax
             }
             FFI_RETURN_IF_ERROR(CheckShape(status->dimensions(), 1, "status", "syevd"));
 
-            SOLVER_DISPATCH_IMPL(SyevdMgImpl, N, batch_a, stream, scratch, a, tile_size, eigenvalues, V, status);
+            SOLVER_DISPATCH_IMPL(SyevdMgImplMp, N, batch_a, stream, scratch, a, tile_size, eigenvalues, V, status);
 
             return ffi::Error::InvalidArgument(absl::StrFormat(
                 "Unsupported data type%s for syevd", absl::FormatStreamed(dataType)));
         }
 
-        XLA_FFI_DEFINE_HANDLER_SYMBOL(SyevdMgFFI, SyevdMgDispatch,
+        XLA_FFI_DEFINE_HANDLER_SYMBOL(SyevdMgMpFFI, SyevdMgMpDispatch,
                                       ffi::Ffi::Bind()
                                           .Ctx<ffi::PlatformStream<gpuStream_t>>()
                                           .Ctx<ffi::ScratchAllocator>()
@@ -353,5 +425,6 @@ namespace jax
         );
 
 #undef SOLVER_DISPATCH_IMPL
+
     } // namespace JAX_GPU_NAMESPACE
 } // namespace jax

--- a/src/cuda/syevd_no_V.cu
+++ b/src/cuda/syevd_no_V.cu
@@ -138,12 +138,11 @@ namespace jax
             cudaLibMgGrid_t gridA;                                                                // CusolverMg grid descriptors
             cusolverMgGridMapping_t mapping = CUDALIBMG_GRID_MAPPING_COL_MAJOR;                   // Column major a la Scalapack
             cusolverEigMode_t jobz = CUSOLVER_EIG_MODE_NOVECTOR;                                  // Wether to return both eigenvectors and eigenvalues
-            // FFI_ASSIGN_OR_RETURN(auto cusolverHPool, SolverHandlePool::Borrow(stream));           // Assign a cusolver handle from the pool
-            cusolverMgHandle_t cusolverH = nullptr;  // cusolverHPool.get();
-            int info = 0;                            // Info used by cusolverMg calls
-            cusolverStatus_t cusolver_status;        // Return status of cusolverMg calls
-            auto status_data = status->typed_data(); // Status returned by syevd
-            int64_t lwork_syevd = 0;                 // Workspace size used by cusolverMg calls
+            cusolverMgHandle_t cusolverH = nullptr;                                               // cusolverHPool.get();
+            int info = 0;                                                                         // Info used by cusolverMg calls
+            cusolverStatus_t cusolver_status;                                                     // Return status of cusolverMg calls
+            auto status_data = status->typed_data();                                              // Status returned by syevd
+            int64_t lwork_syevd = 0;                                                              // Workspace size used by cusolverMg calls
 
             /* Shared memory */
             static std::once_flag barrier_initialized; // Initialize barrier once between threads
@@ -201,7 +200,6 @@ namespace jax
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
 
-            // std::printf("Step 9: Allocate workspace \n");
             if (currentDevice == 0)
             {
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgSyevd_bufferSize(cusolverH, jobz, CUBLAS_FILL_MODE_LOWER, N,
@@ -261,14 +259,17 @@ namespace jax
 
             if (currentDevice == 0)
             {
-                // Copy solution to device 0
-                JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(
-                    shmev[0], eigenvalues_host.data(), sizeof(data_type) * N, gpuMemcpyHostToDevice));
-                CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
-                // Copy solution to all other devices
-                for (int dev = 1; dev < nbGpus; dev++)
-                {
-                    JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(shmev[dev], shmev[0], sizeof(data_type) * N, gpuMemcpyDeviceToDevice));
+
+                if (cusolver_status_host[0] == 0)
+                { // Copy solution to device 0
+                    JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(
+                        shmev[0], eigenvalues_host.data(), sizeof(data_type) * N, gpuMemcpyHostToDevice));
+                    CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
+                    // Copy solution to all other devices
+                    for (int dev = 1; dev < nbGpus; dev++)
+                    {
+                        JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(shmev[dev], shmev[0], sizeof(data_type) * N, gpuMemcpyDeviceToDevice));
+                    }
                 }
             }
 
@@ -284,9 +285,7 @@ namespace jax
             if (currentDevice == 0)
             {
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyMatrixDesc(descrA));
-
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyGrid(gridA));
-
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroy(cusolverH));
 
                 sharedMemoryCleanup(&shminfoA, "shmA");

--- a/src/cuda/syevd_no_V.cu
+++ b/src/cuda/syevd_no_V.cu
@@ -130,7 +130,6 @@ namespace jax
             const int IA = 1; // index within a global matrix, base-1 (not used)
             const int JA = 1;
             const int T_A = std::min(tile_size, batch_a); // tile size of A
-            const int lda = N;                            // leading dimension of local A
 
             /* CUDA */
             cudaDataType compute_type = traits<data_type>::cuda_data_type;                        // Data type for computation

--- a/src/cuda/syevd_no_V_mp.cu
+++ b/src/cuda/syevd_no_V_mp.cu
@@ -66,17 +66,18 @@
 #include "jaxlib/gpu/vendor.h"
 // XLA
 #include "xla/ffi/api/ffi.h"
+#include "xla/ffi/api/c_api.h"
 // CUDA
 #include "third_party/gpus/cuda/include/cusolverMg.h"
 #include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "third_party/gpus/cuda/include/cuda_runtime.h"
+#include "third_party/gpus/cuda/include/cuda.h"
 // My Code
 #include "utils/jax_utils.h"
 #include "cusolver_utils.h"
-#include "thread_barrier.h"
+#include "process_barrier.h"
 #include "utils/shm.h"
-
-ThreadBarrier sync_point;
+#include "utils/ipc_utils.h"
 
 namespace jax
 {
@@ -98,21 +99,21 @@ namespace jax
     default:                                       \
         break;                                     \
     }
+
         template <typename data_type>
-        ffi::Error SyevdMgImpl(int64_t N, int64_t batch_a,
-                               gpuStream_t stream, ffi::ScratchAllocator &scratch,
-                               ffi::AnyBuffer a, int64_t tile_size,
-                               ffi::Result<ffi::AnyBuffer> eigenvalues,
-                               ffi::Result<ffi::AnyBuffer> V,
-                               ffi::Result<ffi::Buffer<ffi::S32>> status)
+        ffi::Error SyevdNoVMgImplMp(int64_t N, int64_t batch_a,
+                                    gpuStream_t stream, ffi::ScratchAllocator &scratch,
+                                    ffi::AnyBuffer a, int64_t tile_size,
+                                    ffi::Result<ffi::AnyBuffer> eigenvalues,
+                                    ffi::Result<ffi::Buffer<ffi::S32>> status)
         {
             /* misc */
-            const std::string &source = __FILE__; // file name for error messages
+            const std::string &source = __FILE__;
 
             /* GPU */
-            const int MAX_NUM_DEVICES = 16; // cusolverMg can handle 16 GPUs at most
-            int nbGpus = 0;                 // number of GPUs to use
-            int currentDevice = 0;          // current GPU
+            const int MAX_NUM_DEVICES = 16;
+            int nbGpus = 0;
+            int currentDevice = 0;
             CUDA_CHECK_OR_RETURN(cudaGetDeviceCount(&nbGpus));
             CUDA_CHECK_OR_RETURN(cudaGetDevice(&currentDevice));
             if (nbGpus > MAX_NUM_DEVICES)
@@ -120,55 +121,71 @@ namespace jax
                 return ffi::Error::InvalidArgument(
                     absl::StrFormat("%s: Number of Gpus must be <=16, received %d", source, nbGpus));
             }
-            std::vector<int> deviceList(nbGpus); // list of device IDs
+            std::vector<int> deviceList(nbGpus);
 
             /* data */
-            auto array_data_A = static_cast<data_type *>(a.untyped_data()); // XLA device pointer for a
+            auto array_data_A = static_cast<data_type *>(a.untyped_data());
             auto array_data_eigenvalues = static_cast<data_type *>(eigenvalues->untyped_data());
-            auto array_data_V = static_cast<data_type *>(V->untyped_data());
-            std::vector<typename traits<data_type>::S> eigenvalues_host(N, 0.); // Make vector of Real datatype
+            std::vector<typename traits<data_type>::S> eigenvalues_host(N, 0.);
 
             /* Tiling sizes */
-            const int IA = 1; // index within a global matrix, base-1 (not used)
+            const int IA = 1;
             const int JA = 1;
-            const int T_A = std::min(tile_size, batch_a); // tile size of A
+            const int T_A = std::min(tile_size, batch_a);
 
             /* CUDA */
-            cudaDataType compute_type = traits<data_type>::cuda_data_type;                        // Data type for computation
-            cudaDataType eigenvalue_type = traits<typename traits<data_type>::S>::cuda_data_type; // Real data type used
-            cudaLibMgMatrixDesc_t descrA;                                                         // CusolverMg matrix descriptors
-            cudaLibMgGrid_t gridA;                                                                // CusolverMg grid descriptors
-            cusolverMgGridMapping_t mapping = CUDALIBMG_GRID_MAPPING_COL_MAJOR;                   // Column major a la Scalapack
-            cusolverEigMode_t jobz = CUSOLVER_EIG_MODE_VECTOR;                                    // Wether to return both eigenvectors and eigenvalues
-            FFI_ASSIGN_OR_RETURN(auto cusolverHPool, SolverHandlePool::Borrow(stream));           // Assign a cusolver handle from the pool
-            cusolverMgHandle_t cusolverH = nullptr;                                               // cusolverHPool.get();
-            int info = 0;                                                                         // Info used by cusolverMg calls
-            cusolverStatus_t cusolver_status;                                                     // Return status of cusolverMg calls
-            auto status_data = status->typed_data();                                              // Status returned by syevd
-            int64_t lwork_syevd = 0;                                                              // Workspace size used by cusolverMg calls
+            cudaDataType compute_type = traits<data_type>::cuda_data_type;
+            cudaDataType eigenvalue_type = traits<typename traits<data_type>::S>::cuda_data_type;
+            cudaLibMgMatrixDesc_t descrA;
+            cudaLibMgGrid_t gridA;
+            cusolverMgGridMapping_t mapping = CUDALIBMG_GRID_MAPPING_COL_MAJOR;
+            cusolverEigMode_t jobz = CUSOLVER_EIG_MODE_NOVECTOR;
+            cusolverMgHandle_t cusolverH = nullptr;
+            int info = 0;
+            cusolverStatus_t cusolver_status;
+            auto status_data = status->typed_data();
+            int64_t lwork_syevd = 0;
 
-            /* Shared memory */
-            static std::once_flag barrier_initialized; // Initialize barrier once between threads
-            std::call_once(barrier_initialized, [&]()
-                           { sync_point.initialize(nbGpus); });
+            /* Shared memory (multi-process barrier) */
+            const pid_t ppid = getppid();
+            const std::string barrier_name = "/jaxmgbarrier_" + std::to_string(static_cast<long long>(ppid));
+            DynamicBarrier sync_point(nbGpus, barrier_name.c_str());
             sync_point.arrive_and_wait();
-            sharedMemoryInfo shminfoA;  // Shared memory info for device pointers to local matrices
-            sharedMemoryInfo shminfoev; // Shared memory info for device pointers to local matrices
-            sharedMemoryInfo shminfowork;
-            sharedMemoryInfo shminfolwork; // Shared memory info for lwork space nbytes
-            sharedMemoryInfo shmcsh;       // Shared memory info for cusolver status
+            CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
 
-            data_type **shmA = get_shm_device_ptrs<data_type>(currentDevice, sync_point, shminfoA, "shmA");    // Actual shared memory
-            data_type **shmev = get_shm_device_ptrs<data_type>(currentDevice, sync_point, shminfoev, "shmev"); // Actual shared memory
-            data_type **shmwork = get_shm_device_ptrs<data_type>(currentDevice, sync_point, shminfowork, "shmwork");
+            sharedMemoryInfo shminfoAipc;        // Shared memory info for device pointers to local matrices A
+            sharedMemoryInfo shminfo_offsetA;    // Shared memory info for offsets of A pointers
+            sharedMemoryInfo shminfoevipc;       // Shared memory info for device pointers to eigenvalue arrays
+            sharedMemoryInfo shminfo_offsetev;   // Shared memory info for offsets of eigenvalue pointers
+            sharedMemoryInfo shminfoworkipc;     // Shared memory info for workspace pointers
+            sharedMemoryInfo shminfo_offsetwork; // Shared memory info for offsets of workspace pointers
+            sharedMemoryInfo shminfolwork;       // Shared memory info for lwork
+            sharedMemoryInfo shminfo_csh;        // Shared memory info for cusolver status
 
-            int32_t *cusolver_status_host = get_shm_lwork_ptr<int32_t, ThreadBarrier>(currentDevice, sync_point, shmcsh, "shmcsh");
-            int64_t *shmlwork = get_shm_lwork_ptr<int64_t, ThreadBarrier>(currentDevice, sync_point, shminfolwork, "shmlwork");
+            // Data handles A
+            std::vector<data_type *> shmA(nbGpus, nullptr);
+            IpcOpenResult<data_type> opened_ptrs_A;
+            cudaIpcMemHandle_t *shmAipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoAipc, "shmAipc");
+            uintptr_t *shmoffsetA = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetA, "shmoffsetA");
+
+            // Data handles eigenvalues
+            std::vector<data_type *> shmev(nbGpus, nullptr);
+            IpcOpenResult<data_type> opened_ptrs_ev;
+            cudaIpcMemHandle_t *shmevipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoevipc, "shmevipc");
+            uintptr_t *shmoffsetev = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetev, "shmoffsetev");
+
+            // Workspace
+            std::vector<data_type *> shmwork(nbGpus, nullptr);
+            IpcOpenResult<data_type> opened_ptrs_work;
+            cudaIpcMemHandle_t *shmworkipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoworkipc, "shmworkipc");
+            uintptr_t *shmoffsetwork = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetwork, "shmoffsetwork");
+
+            int32_t *cusolver_status_host = get_shm_lwork_ptr<int32_t>(currentDevice, sync_point, shminfo_csh, "shmcsh");
+            int64_t *shmlwork = get_shm_lwork_ptr<int64_t>(currentDevice, sync_point, shminfolwork, "shmlwork");
 
             if (currentDevice == 0)
             {
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgCreate(&cusolverH));
-
                 for (int j = 0; j < nbGpus; j++)
                 {
                     deviceList[j] = j;
@@ -177,35 +194,58 @@ namespace jax
                 }
 
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDeviceSelect(cusolverH, nbGpus, deviceList.data()));
-
+                
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgCreateDeviceGrid(&gridA, 1, nbGpus, deviceList.data(), mapping));
 
-                /* (global) A is N-by-N */
-                CUSOLVER_CHECK_OR_RETURN(cusolverMgCreateMatrixDesc(&descrA, N, /* number of rows of (global) A */
-                                                                    N,          /* number of columns of (global) A */
-                                                                    N,          /* number or rows in a tile */
-                                                                    T_A,        /* number of columns in a tile */
+                CUSOLVER_CHECK_OR_RETURN(cusolverMgCreateMatrixDesc(&descrA, N,
+                                                                    N,
+                                                                    N,
+                                                                    T_A,
                                                                     compute_type, gridA));
             }
 
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
-            shmA[currentDevice] = array_data_A;
             sync_point.arrive_and_wait();
+
+            // Export local device pointers via CUDA IPC
+            ipcGetHandleAndOffset(array_data_A, shmAipc[currentDevice], shmoffsetA[currentDevice]);
+            ipcGetHandleAndOffset(array_data_eigenvalues, shmevipc[currentDevice], shmoffsetev[currentDevice]);
+
+            CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
+            sync_point.arrive_and_wait();
+
             if (currentDevice == 0)
             {
+                opened_ptrs_A = ipcGetDevicePointers<data_type>(currentDevice, nbGpus, shmAipc, shmoffsetA);
+                opened_ptrs_ev = ipcGetDevicePointers<data_type>(currentDevice, nbGpus, shmevipc, shmoffsetev);
+
+                for (int dev = 1; dev < nbGpus; ++dev)
+                {
+                    shmA[dev] = opened_ptrs_A.ptrs[dev];
+                    shmev[dev] = opened_ptrs_ev.ptrs[dev];
+                }
+                shmA[0] = array_data_A;
+                shmev[0] = array_data_eigenvalues;
+            }
+
+            CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
+            sync_point.arrive_and_wait();
+
+            if (currentDevice == 0)
+            {
+                // Convert input layout to 1D block-cyclic layout across devices
                 memcpyCyclicShard<data_type>(nbGpus, stream, deviceList.data(),
                                              N, batch_a, T_A,
                                              /* input */
-                                             shmA, false);
+                                             shmA.data(), false);
             }
-
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
 
             if (currentDevice == 0)
             {
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgSyevd_bufferSize(cusolverH, jobz, CUBLAS_FILL_MODE_LOWER, N,
-                                                                    reinterpret_cast<void **>(shmA), IA, JA, descrA,
+                                                                    reinterpret_cast<void **>(shmA.data()), IA, JA, descrA,
                                                                     reinterpret_cast<void *>(eigenvalues_host.data()),
                                                                     eigenvalue_type, compute_type,
                                                                     &lwork_syevd));
@@ -215,15 +255,22 @@ namespace jax
                     shmlwork[dev] = lwork_syevd;
                 }
             }
+
             sync_point.arrive_and_wait();
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
 
-            /* array_d_work[j] points to device workspace of device j */
-            FFI_ASSIGN_OR_RETURN(auto workspace, AllocateWorkspaceBytes<data_type>(scratch, sizeof(data_type) * (shmlwork[currentDevice]), "workspace_syevd"));
-            shmwork[currentDevice] = workspace;
-            shmev[currentDevice] = array_data_eigenvalues;
+            // Workspace size in bytes for current device
+            size_t workspace_bytes = sizeof(data_type) * static_cast<size_t>(shmlwork[currentDevice]);
 
-            /* sync all devices */
+            sync_point.arrive_and_wait();
+            CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
+
+            if (currentDevice == 0)
+            {
+                workspaceAlloc(nbGpus, deviceList.data(),
+                               workspace_bytes,
+                               reinterpret_cast<void **>(shmwork.data()));
+            }
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
 
@@ -231,41 +278,40 @@ namespace jax
             {
                 cusolver_status = cusolverMgSyevd(
                     cusolverH, jobz, CUBLAS_FILL_MODE_LOWER, N,
-                    reinterpret_cast<void **>(shmA), IA, JA,
+                    reinterpret_cast<void **>(shmA.data()), IA, JA,
                     descrA, reinterpret_cast<void **>(eigenvalues_host.data()),
                     eigenvalue_type, compute_type,
-                    reinterpret_cast<void **>(shmwork), *shmlwork, &info);
+                    reinterpret_cast<void **>(shmwork.data()), shmlwork[currentDevice], &info);
 
-                /* sync all devices */
                 CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
-                // Copy status to all devices
                 for (int dev = 0; dev < nbGpus; dev++)
                 {
                     cusolver_status_host[dev] = static_cast<int32_t>(cusolver_status);
                 }
-                /* check if A is singular */
+
                 if (0 > info)
                 {
                     return ffi::Error::Internal(
                         absl::StrFormat("unexpected error in cusolverMgSyevd, %d-th input parameter is wrong \n", -info));
                 }
             }
-            /* sync all devices */
+
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
 
-            // Write status data
+            // Write status per device
             int32_t status_val = static_cast<int32_t>(cusolver_status_host[currentDevice]);
             JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(status_data, &status_val, sizeof(status_val), gpuMemcpyHostToDevice));
 
             if (currentDevice == 0)
             {
                 if (cusolver_status_host[0] == 0)
-                { // Copy solution to device 0
+                {
+                    // Copy eigenvalues to device 0 eigenvalue buffer
                     JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(
                         shmev[0], eigenvalues_host.data(), sizeof(data_type) * N, gpuMemcpyHostToDevice));
                     CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
-                    // Copy solution to all other devices
+                    // Broadcast eigenvalues to all other devices
                     for (int dev = 1; dev < nbGpus; dev++)
                     {
                         JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(shmev[dev], shmev[0], sizeof(data_type) * N, gpuMemcpyDeviceToDevice));
@@ -275,83 +321,67 @@ namespace jax
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
 
-            if (cusolver_status_host[currentDevice] == 0)
-            {
-                // Unshard eigenvectors from shmA back into V buffers
-                array_data_V = shmA[currentDevice];
-                if (currentDevice == 0)
-                {
-                    memcpyCyclicShard<data_type>(nbGpus, stream, deviceList.data(),
-                                                 N, batch_a, T_A,
-                                                 /* input */
-                                                 shmA, true);
-                }
-            }
-            else
+            if (cusolver_status_host[currentDevice] != 0)
             {
                 std::vector<typename traits<data_type>::T> host_ev_nan(N, traits<data_type>::nan());
-                std::vector<typename traits<data_type>::T> host_V_nan(N * batch_a, traits<data_type>::nan());
                 JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(array_data_eigenvalues, host_ev_nan.data(), sizeof(data_type) * N, gpuMemcpyHostToDevice));
-                JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(array_data_V, host_V_nan.data(), sizeof(data_type) * N * batch_a, gpuMemcpyHostToDevice));
             }
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
-
             if (currentDevice == 0)
             {
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyMatrixDesc(descrA));
-
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyGrid(gridA));
-
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroy(cusolverH));
 
-                sharedMemoryCleanup(&shminfoA, "shmA");
-                sharedMemoryCleanup(&shminfoev, "shmev");
-                sharedMemoryCleanup(&shminfowork, "shmwork");
-                sharedMemoryCleanup(&shmcsh, "shmcsh");
+                sharedMemoryCleanup(&shminfo_offsetA, "shmoffsetA");
+                sharedMemoryCleanup(&shminfoAipc, "shmAipc");
+                sharedMemoryCleanup(&shminfo_offsetev, "shmoffsetev");
+                sharedMemoryCleanup(&shminfoevipc, "shmevipc");
+                sharedMemoryCleanup(&shminfoworkipc, "shmworkipc");
+                sharedMemoryCleanup(&shminfo_offsetwork, "shmoffsetwork");
                 sharedMemoryCleanup(&shminfolwork, "shmlwork");
+                sharedMemoryCleanup(&shminfo_csh, "shmcsh");
+
+                ipcCloseDevicePointers(currentDevice, opened_ptrs_A.bases, nbGpus);
+                ipcCloseDevicePointers(currentDevice, opened_ptrs_ev.bases, nbGpus);
+                workspaceFree(nbGpus, deviceList.data(), reinterpret_cast<void **>(shmwork.data()));
             }
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
-            sync_point.arrive_and_wait();
+            sync_point.close_and_wait();
 
             return ffi::Error::Success();
         }
 
-        ffi::Error SyevdMgDispatch(gpuStream_t stream, ffi::ScratchAllocator scratch,
-                                   ffi::AnyBuffer a, int64_t tile_size,
-                                   ffi::Result<ffi::AnyBuffer> eigenvalues,
-                                   ffi::Result<ffi::AnyBuffer> V,
-                                   ffi::Result<ffi::Buffer<ffi::S32>> status)
+        ffi::Error SyevdNoVMgMpDispatch(gpuStream_t stream, ffi::ScratchAllocator scratch,
+                                        ffi::AnyBuffer a, int64_t tile_size,
+                                        ffi::Result<ffi::AnyBuffer> eigenvalues,
+                                        ffi::Result<ffi::Buffer<ffi::S32>> status)
         {
             auto dataType = a.element_type();
 
             // Rows are batched
             FFI_ASSIGN_OR_RETURN((const auto [batch_a, N]), SplitBatch1D(a.dimensions()));
 
-            if ((dataType != V->element_type()))
-            {
-                return ffi::Error::InvalidArgument(
-                    "The input matrix and output eigenvector dtype of syevd must have the same element type");
-            }
-            FFI_RETURN_IF_ERROR(CheckShape(status->dimensions(), 1, "status", "syevd"));
+            FFI_RETURN_IF_ERROR(CheckShape(status->dimensions(), 1, "status", "syevd_no_V"));
 
-            SOLVER_DISPATCH_IMPL(SyevdMgImpl, N, batch_a, stream, scratch, a, tile_size, eigenvalues, V, status);
+            SOLVER_DISPATCH_IMPL(SyevdNoVMgImplMp, N, batch_a, stream, scratch, a, tile_size, eigenvalues, status);
 
             return ffi::Error::InvalidArgument(absl::StrFormat(
-                "Unsupported data type%s for syevd", absl::FormatStreamed(dataType)));
+                "Unsupported data type%s for syevd_no_V", absl::FormatStreamed(dataType)));
         }
 
-        XLA_FFI_DEFINE_HANDLER_SYMBOL(SyevdMgFFI, SyevdMgDispatch,
+        XLA_FFI_DEFINE_HANDLER_SYMBOL(SyevdNoVMgMpFFI, SyevdNoVMgMpDispatch,
                                       ffi::Ffi::Bind()
                                           .Ctx<ffi::PlatformStream<gpuStream_t>>()
                                           .Ctx<ffi::ScratchAllocator>()
                                           .Arg<ffi::AnyBuffer>()        // A
                                           .Attr<int64_t>("T_A")         // tile size
                                           .Ret<ffi::AnyBuffer>()        // eigenvalues
-                                          .Ret<ffi::AnyBuffer>()        // V
                                           .Ret<ffi::Buffer<ffi::S32>>() // status
         );
 
 #undef SOLVER_DISPATCH_IMPL
+
     } // namespace JAX_GPU_NAMESPACE
 } // namespace jax

--- a/src/jaxmg/__init__.py
+++ b/src/jaxmg/__init__.py
@@ -117,10 +117,37 @@ if any("gpu" == d.platform for d in jax.devices()):
             os.path.dirname(__file__), f"{bin_dir}/libpotrs_mp.so"
         )
         library_potrs_mp = ctypes.cdll.LoadLibrary(SHARED_LIBRARY_POTRS_MP)
+        SHARED_LIBRARY_POTRI_MP = os.path.join(
+            os.path.dirname(__file__), f"{bin_dir}/libpotri_mp.so"
+        )
+        library_potri_mp = ctypes.cdll.LoadLibrary(SHARED_LIBRARY_POTRI_MP)
+        SHARED_LIBRARY_SYEVD_MP = os.path.join(
+            os.path.dirname(__file__), f"{bin_dir}/libsyevd_mp.so"
+        )
+        library_syevd_mp = ctypes.cdll.LoadLibrary(SHARED_LIBRARY_SYEVD_MP)
+        SHARED_LIBRARY_SYEVD_NO_V_MP = os.path.join(
+            os.path.dirname(__file__), f"{bin_dir}/libsyevd_no_V_mp.so"
+        )
+        library_syevd_no_V_mp = ctypes.cdll.LoadLibrary(SHARED_LIBRARY_SYEVD_NO_V_MP)
         # Register FFI targets
         jax.ffi.register_ffi_target(
             "potrs_mg",
             jax.ffi.pycapsule(library_potrs_mp.PotrsMgMpFFI),
+            platform="CUDA",
+        )
+        jax.ffi.register_ffi_target(
+            "potri_mg",
+            jax.ffi.pycapsule(library_potri_mp.PotriMgMpFFI),
+            platform="CUDA",
+        )
+        jax.ffi.register_ffi_target(
+            "syevd_mg",
+            jax.ffi.pycapsule(library_syevd_mp.SyevdMgMpFFI),
+            platform="CUDA",
+        )
+        jax.ffi.register_ffi_target(
+            "syevd_no_V_mg",
+            jax.ffi.pycapsule(library_syevd_no_V_mp.SyevdNoVMgMpFFI),
             platform="CUDA",
         )
     from ._potrs import potrs, potrs_shardmap_ctx

--- a/src/jaxmg/_potri.py
+++ b/src/jaxmg/_potri.py
@@ -191,10 +191,6 @@ def potri_shardmap_ctx(a: Array, T_A: int, pad=True) -> Union[Array, Tuple[Array
         To achieve the full inverse, call ``jaxmg.potri_symmetrize`` outside of
         the shardmap_context.
 
-    Warning:
-        Multi-process multiple device (MPMD) mode is not supported right now but will
-        be in a future release.
-
     Tip:
         If the shards of the matrix cannot be padded with tiles of size `T_A`
         (``N / num_gpus % T_A != 0``) we have to add padding to fit the last tile.

--- a/src/jaxmg/_syevd.py
+++ b/src/jaxmg/_syevd.py
@@ -241,10 +241,6 @@ def syevd_shardmap_ctx(
     ``syevd_no_V_mg`` FFI targets via ``jax.ffi.ffi_call`` instead of
     constructing an additional ``shard_map`` wrapper.
 
-    Warning:
-        Multi-process multiple device (MPMD) mode is not supported right now but will
-        be in a future release.
-
     Tip:
         If the shards of the matrix cannot be padded with tiles of size `T_A`
         (``N / num_gpus % T_A != 0``) we have to add padding to fit the last tile.

--- a/test_potri_mp.py
+++ b/test_potri_mp.py
@@ -1,0 +1,79 @@
+# In file gpu_example.py...
+import os
+
+# os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
+# os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] = "platform"
+# os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = ".95"
+# os.environ["TF_GPU_ALLOCATOR"] = "cuda_malloc_async"
+# os.environ["JAXMG_CUSOLVER_UTILS_VERBOSE"] = "1"
+os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] = "platform"
+
+import jax
+import sys
+
+
+
+def random_psd(n, dtype, seed):
+    """
+    Generate a random n x n positive semidefinite matrix.
+    """
+    key = jax.random.key(seed)
+    A = jax.random.normal(key, (n, n), dtype=dtype) / jnp.sqrt(n)
+    return A @ A.T.conj() + jnp.eye(n, dtype=dtype) * 1e-5  # symmetric PSD
+
+#
+N = 8
+print("N=", N)
+NRHS = 1
+T_A = 1  # From 2120 onwards it gives NaN
+
+
+print("shards", (N // 2) / T_A)
+
+# Get the coordinator_address, process_id, and num_processes from the command line.
+coord_addr = sys.argv[1]
+proc_id = int(sys.argv[2])
+num_procs = int(sys.argv[3])
+
+# Initialize the GPU machines.
+jax.distributed.initialize(
+    coordinator_address=coord_addr,
+    num_processes=num_procs,
+    process_id=proc_id,
+    local_device_ids=proc_id,
+)
+print("process id =", jax.process_index())
+print("global devices =", jax.devices())
+print("local devices =", jax.local_devices())
+print("visible devices", os.environ["CUDA_VISIBLE_DEVICES"])
+import jax.numpy as jnp
+
+from jax.sharding import NamedSharding, PartitionSpec as P
+from jaxmg import potri, syevd
+from jaxmg import determine_distributed_setup
+from jaxmg import calculate_padding
+from jaxmg.utils import random_psd
+from jax.experimental.multihost_utils import process_allgather
+print(determine_distributed_setup())
+dtype = jnp.complex64
+ndev = int(os.environ["JAXMG_NUMBER_OF_DEVICES"])
+chunk_size = N // ndev
+mesh = jax.make_mesh((ndev,), ("x",))
+
+
+@jax.jit
+def run_once():
+    _A = jax.lax.with_sharding_constraint(
+        # random_psd(N, dtype=dtype, seed=100),
+        jnp.diag(jnp.arange(N, dtype=dtype) + 1), 
+        NamedSharding(mesh, P("x", None))
+    )
+    return _A
+
+
+A = run_once()
+
+out, status = potri(A, T_A, mesh, (P("x", None), ), return_status=True, pad=True)
+print(process_allgather(out, tiled=True))
+print(status)
+exit()

--- a/tests/mpmd/mpmd_helper.py
+++ b/tests/mpmd/mpmd_helper.py
@@ -37,7 +37,7 @@ def run_mpmd_test(mp_test: Path, requested_procs: int, name: str, dtype_name: st
     coord = f"127.0.0.1:{port}"
 
     env = os.environ.copy()
-    env.setdefault("XLA_PYTHON_CLIENT_PREALLOCATE", "false")
+    env.setdefault("XLA_PYTHON_CLIENT_PREALLOCATE", "platform")
 
     here = mp_test.parent
     print(f"[launcher] starting task {name}: dtype={dtype_name}, procs={requested_procs}")

--- a/tests/mpmd/mpmd_helper.py
+++ b/tests/mpmd/mpmd_helper.py
@@ -1,0 +1,139 @@
+import os
+import sys
+import socket
+import subprocess
+import time
+import json
+from pathlib import Path
+from typing import List
+
+import pytest
+import jax
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def run_mpmd_test(mp_test: Path, requested_procs: int, name: str, dtype_name: str) -> None:
+    """Launch an MPMD test runner script across processes and assert success.
+
+    The runner script is expected to emit single-line JSON messages prefixed
+    with ``MPTEST_RESULT`` and ``MPTEST_SUMMARY`` describing per-process
+    outcomes. This helper handles launching, log collection, parsing, and
+    basic validation.
+    """
+
+    # Quick guard: ensure visible GPUs still match the requested value.
+    gpu_count = jax.device_count("gpu")
+    if gpu_count != requested_procs:
+        pytest.skip(
+            f"Need {requested_procs} GPUs in CUDA_VISIBLE_DEVICES to run this test (have {gpu_count})"
+        )
+
+    port = _find_free_port()
+    coord = f"127.0.0.1:{port}"
+
+    env = os.environ.copy()
+    env.setdefault("XLA_PYTHON_CLIENT_PREALLOCATE", "false")
+
+    here = mp_test.parent
+    print(f"[launcher] starting task {name}: dtype={dtype_name}, procs={requested_procs}")
+
+    procs: List[subprocess.Popen] = []
+    logs: List[str] = []
+    for i in range(requested_procs):
+        cmd = [
+            sys.executable,
+            "-u",
+            str(mp_test),
+            coord,
+            str(i),
+            str(requested_procs),
+            name,
+            dtype_name,
+        ]
+        p = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=env,
+            cwd=str(here),
+            text=True,
+            bufsize=1,
+        )
+        procs.append(p)
+
+    # Collect output with a timeout to avoid hanging the test suite
+    deadline = time.time() + 150
+    for idx, p in enumerate(procs):
+        out_chunks: List[str] = []
+        while p.poll() is None and time.time() < deadline:
+            assert p.stdout is not None
+            line = p.stdout.readline()
+            if line:
+                out_chunks.append(line)
+        remaining = p.stdout.read() or ""  # type: ignore[union-attr]
+        if remaining:
+            out_chunks.append(remaining)
+        logs.append("".join(out_chunks))
+
+    # Ensure all processes exited
+    exits = [p.wait(timeout=5) for p in procs]
+    for idx, code in enumerate(exits):
+        if code != 0:
+            print(f"===== mp_test proc {idx} combined output =====")
+            print(logs[idx])
+        assert code == 0, f"mp_test process {idx} failed with exit code {code}"
+
+    # Parse MPTEST JSON lines and aggregate results
+    parsed = []
+    per_proc_seen = set()
+    for idx, log in enumerate(logs):
+        for line in log.splitlines():
+            try:
+                if line.startswith("MPTEST_RESULT "):
+                    payload = json.loads(line.split(" ", 1)[1])
+                    parsed.append(payload)
+                    per_proc_seen.add(payload.get("proc"))
+                elif line.startswith("MPTEST_SUMMARY "):
+                    payload = json.loads(line.split(" ", 1)[1])
+                    per_proc_seen.add(payload.get("proc"))
+            except json.JSONDecodeError:
+                # Ignore non-JSON lines
+                pass
+
+    expected_procs = set(range(requested_procs))
+    assert expected_procs.issubset(per_proc_seen), (
+        f"Missing results from some processes for task {name} dtype={dtype_name}. "
+        f"expected={sorted(expected_procs)} seen={sorted(per_proc_seen)}\n"
+        f"Raw logs:\n" + "\n\n".join(f"===== proc {i} =====\n{l}" for i, l in enumerate(logs))
+    )
+
+    failures = [r for r in parsed if r.get("status") == "fail"]
+    if failures:
+        def _short_msg(tb: str) -> str:
+            if not tb:
+                return ""
+            lines = [ln for ln in tb.splitlines() if ln.strip()]
+            return lines[-1] if lines else tb.strip()
+
+        summary_lines = [f"Task {name} dtype={dtype_name} failures:"]
+        for r in failures:
+            summary_lines.append(
+                f"- proc {r.get('proc')} :: {r.get('name')}: {_short_msg(r.get('traceback',''))}"
+            )
+        summary_lines.append("")
+        for i, l in enumerate(logs):
+            summary_lines.append(f"===== proc {i} =====\n{l}")
+        pytest.fail("\n".join(summary_lines))
+
+    ok_count = sum(1 for r in parsed if r.get("status") == "ok")
+    assert ok_count > 0, (
+        f"Expected at least one ok result for task {name} dtype={dtype_name}; raw logs:\n"
+        + "\n\n".join(logs)
+    )
+
+    print(f"[launcher] task {name} dtype={dtype_name} completed successfully")

--- a/tests/mpmd/run_potri.py
+++ b/tests/mpmd/run_potri.py
@@ -1,0 +1,220 @@
+import os
+import sys
+import json
+import traceback
+from typing import Callable, Dict, List
+
+import jax
+
+coord_addr = sys.argv[1]
+proc_id = int(sys.argv[2])
+num_procs = int(sys.argv[3])
+
+# Initialize the GPU machines.
+jax.distributed.initialize(
+    coordinator_address=coord_addr,
+    num_processes=num_procs,
+    process_id=proc_id,
+    local_device_ids=proc_id,
+    coordinator_bind_address=coord_addr,
+)
+
+# Basic diagnostics for debugging
+print("process id =", jax.process_index(), flush=True)
+print("global devices =", jax.devices(), flush=True)
+print("local devices =", jax.local_devices(), flush=True)
+print("visible devices", os.environ.get("CUDA_VISIBLE_DEVICES", ""), flush=True)
+
+
+def _println(prefix: str, payload: dict):
+    """Print a single-line JSON payload with a stable prefix for log parsing."""
+    print(f"{prefix} {json.dumps(payload, sort_keys=True)}", flush=True)
+
+
+import jax.numpy as jnp
+from jax.sharding import NamedSharding, PartitionSpec as P
+from functools import partial
+
+
+# These will be initialized after jax.distributed.initialize()
+devices = [d for d in jax.devices() if d.platform == "gpu"]
+mesh = jax.make_mesh((jax.device_count(),), ("x",))
+
+from jaxmg import potri, potri_shardmap_ctx, potri_symmetrize
+from jaxmg.utils import random_psd
+
+
+@partial(jax.jit, static_argnames=("_T_A",))
+def jitted_potri(_a, _T_A):
+    out = partial(potri, mesh=mesh, in_specs=(P("x", None),), pad=True)(_a, _T_A)
+    jax.debug.print("{}", out)
+    return out
+
+
+@partial(jax.jit, static_argnames=("_T_A",))
+def jitted_potri_status(_a, _T_A):
+    out, status = partial(
+        potri, mesh=mesh, in_specs=(P("x", None),), pad=True, return_status=True
+    )(_a, _T_A)
+    return out, status
+
+
+@partial(jax.jit, static_argnames=("_T_A",))
+def jitted_potri_no_shardmap(_a, _T_A):
+    out, status = jax.shard_map(
+        partial(potri_shardmap_ctx, T_A=_T_A),
+        mesh=mesh,
+        in_specs=(P("x", None),),
+        out_specs=(P("x", None), P(None)),
+        check_vma=False,
+    )(_a)
+    return out, status
+
+
+def cusolver_solve_arange(N, T_A, dtype):
+    A = jnp.diag(jnp.arange(N, dtype=dtype) + 1)
+    # Make mesh and place data
+    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+
+    out = jitted_potri(_A.copy(), T_A)
+    expected_out = jnp.diag(1.0 / (jnp.arange(N, dtype=dtype) + 1))
+    assert jnp.allclose(out, expected_out)
+
+    out_no_shm, _ = jitted_potri_no_shardmap(_A.copy(), T_A)
+    out_no_shm = potri_symmetrize(out_no_shm)
+    assert jnp.allclose(out, out_no_shm)
+
+
+def cusolver_solve_psd(N, T_A, dtype):
+    A = random_psd(N, dtype=dtype, seed=1234)
+    expected_out = jnp.linalg.inv(A)
+    # Make mesh and place data
+    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+
+    out = jitted_potri(_A.copy(), T_A)
+    assert jnp.allclose(A.conj().T, A)
+    norm_potri = jnp.linalg.norm(A @ out - jnp.eye(N, dtype=dtype))
+    norm_lax = jnp.linalg.norm(A @ expected_out - jnp.eye(N, dtype=dtype))
+    assert jnp.isclose(norm_potri, norm_lax, rtol=10, atol=1e-8)
+
+    out_no_shm, _ = jitted_potri_no_shardmap(_A.copy(), T_A)
+    out_no_shm = potri_symmetrize(out_no_shm)
+    norm_potri_no_shm = jnp.linalg.norm(A @ out_no_shm - jnp.eye(N, dtype=dtype))
+    assert jnp.allclose(norm_potri_no_shm, norm_lax, rtol=10, atol=1e-8)
+
+
+def cusolver_solve_non_psd(N, T_A, dtype):
+    A = jnp.diag(jnp.arange(N, dtype=dtype) - 1)
+    # Make mesh and place data
+    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+
+    out, status = jitted_potri_status(_A.copy(), T_A)
+    status.block_until_ready()
+    out.block_until_ready()
+    assert status == 7
+    assert jnp.all(jnp.isnan(out))
+
+
+def cusolver_solve_non_symm(N, T_A, dtype):
+    A = jnp.diag(jnp.arange(N, dtype=dtype) + 1)
+    # TODO: For some reason the solver does not fail when we set this to 1.0.
+    A = A.at[0, 1].set(2.0)
+    # Make mesh and place data
+    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+
+    out, status = jitted_potri_status(_A.copy(), T_A)
+    status.block_until_ready()
+    out.block_until_ready()
+    assert status == 7
+    assert jnp.all(jnp.isnan(out))
+
+
+def _build_registry() -> Dict[str, Callable]:
+    # Map test names to callables that accept (N, T_A, dtype)
+    return {
+        "arange": cusolver_solve_arange,
+        "non_psd": cusolver_solve_non_psd,
+        "non_symm": cusolver_solve_non_symm,
+        "psd": cusolver_solve_psd,
+    }
+
+
+def main(argv: List[str]):
+    # Single-task only: expect arguments
+    # run_potri.py <coord_addr> <proc_id> <num_procs> <test_name> <dtype_name>
+
+    task_name = argv[4]
+    task_dtype_name = argv[5]
+    registry = _build_registry()
+
+    # Parameter grid metadata (for discover message)
+    ndev = len(devices)
+    dtypes = [jnp.float32, jnp.float64, jnp.complex64, jnp.complex128]
+    N_list = list(i * ndev for i in [2, 3, 4, 10])
+    T_A_list = [1, 2, 3, 5]
+    for task_N in N_list:
+        for task_T_A in T_A_list:
+            params_summary = {
+                "N": [task_N],
+                "T_A": [task_T_A],
+                "dtype": [task_dtype_name],
+            }
+
+            # Announce discovery for this single task
+            _println(
+                "MPTEST_DISCOVER",
+                {
+                    "proc": proc_id,
+                    "available": sorted(registry.keys()),
+                    "selected": [task_name],
+                    "params": params_summary,
+                },
+            )
+
+            fn = registry[task_name]
+            # Map dtype name to jnp dtype
+            dt = next(dt for dt in dtypes if jnp.dtype(dt).name == task_dtype_name)
+            n_ok = 0
+            n_fail = 0
+            try:
+                fn(task_N, task_T_A, dt)
+                _println(
+                    "MPTEST_RESULT",
+                    {
+                        "proc": proc_id,
+                        "name": task_name,
+                        "status": "ok",
+                        "params": {
+                            "N": task_N,
+                            "T_A": task_T_A,
+                            "dtype": task_dtype_name,
+                        },
+                    },
+                )
+                n_ok += 1
+            except Exception:
+                tb = traceback.format_exc(limit=40)
+                _println(
+                    "MPTEST_RESULT",
+                    {
+                        "proc": proc_id,
+                        "name": task_name,
+                        "status": "fail",
+                        "params": {
+                            "N": task_N,
+                            "T_A": task_T_A,
+                            "dtype": task_dtype_name,
+                        },
+                        "traceback": tb,
+                    },
+                )
+                n_fail += 1
+
+            _println(
+                "MPTEST_SUMMARY",
+                {"proc": proc_id, "ok": n_ok, "fail": n_fail, "total": n_ok + n_fail},
+            )
+            return 0
+
+
+main(sys.argv)

--- a/tests/mpmd/run_syevd.py
+++ b/tests/mpmd/run_syevd.py
@@ -1,0 +1,225 @@
+import os
+import sys
+import json
+import traceback
+from typing import Callable, Dict, List
+
+import jax
+
+coord_addr = sys.argv[1]
+proc_id = int(sys.argv[2])
+num_procs = int(sys.argv[3])
+
+# Initialize the GPU machines.
+jax.distributed.initialize(
+    coordinator_address=coord_addr,
+    num_processes=num_procs,
+    process_id=proc_id,
+    local_device_ids=proc_id,
+    coordinator_bind_address=coord_addr,
+)
+
+# Basic diagnostics for debugging
+print("process id =", jax.process_index(), flush=True)
+print("global devices =", jax.devices(), flush=True)
+print("local devices =", jax.local_devices(), flush=True)
+print("visible devices", os.environ.get("CUDA_VISIBLE_DEVICES", ""), flush=True)
+
+
+def _println(prefix: str, payload: dict):
+    """Print a single-line JSON payload with a stable prefix for log parsing."""
+    print(f"{prefix} {json.dumps(payload, sort_keys=True)}", flush=True)
+
+
+import jax.numpy as jnp
+from jax.sharding import NamedSharding, PartitionSpec as P
+from functools import partial
+
+
+# These will be initialized after jax.distributed.initialize()
+devices = [d for d in jax.devices() if d.platform == "gpu"]
+mesh = jax.make_mesh((jax.device_count(),), ("x",))
+
+from jaxmg import syevd, syevd_shardmap_ctx
+from jaxmg.utils import random_psd
+
+
+@partial(jax.jit, static_argnames=("_T_A",))
+def jitted_syevd(_a, _T_A):
+    eigenvalues, V = partial(syevd, mesh=mesh, in_specs=(P("x", None),), pad=True)(
+        _a, _T_A
+    )
+    return eigenvalues, V
+
+
+@partial(jax.jit, static_argnames=("_T_A",))
+def jitted_syevd_no_shardmap(_a, _T_A):
+    eigenvalues, V, status = jax.shard_map(
+        partial(syevd_shardmap_ctx, T_A=_T_A),
+        mesh=mesh,
+        in_specs=(P("x", None),),
+        out_specs=(P(None), P(None, None), P(None)),
+        check_vma=False,
+    )(_a)
+    return eigenvalues, V, status
+
+
+@partial(jax.jit, static_argnames=("_T_A",))
+def jitted_syevd_no_V(_a, _T_A):
+    eigenvalues = partial(
+        syevd, mesh=mesh, in_specs=(P("x", None),), return_eigenvectors=False, pad=True
+    )(_a, _T_A)
+    return eigenvalues
+
+
+@partial(jax.jit, static_argnames=("_T_A",))
+def jitted_syevd_no_V_no_shardmap(_a, _T_A):
+    eigenvalues, status = jax.shard_map(
+        partial(syevd_shardmap_ctx, T_A=_T_A, return_eigenvectors=False),
+        mesh=mesh,
+        in_specs=(P("x", None),),
+        out_specs=(P(None), P(None)),
+        check_vma=False,
+    )(_a)
+    return eigenvalues, status
+
+
+def cusolver_solve_arange(N, T_A, dtype):
+    A = jnp.diag(jnp.arange(N, dtype=dtype) + 1)
+    eigenvalues_expected = jnp.diag(A)
+    # Make mesh and place data
+    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+    eigenvalues, V = jitted_syevd(_A.copy(), T_A)
+    assert jnp.allclose(eigenvalues_expected, eigenvalues)
+    eigenvalues_VtAV = jnp.diag(V @ A @ V.T)
+    assert jnp.allclose(eigenvalues_VtAV, eigenvalues_expected)
+    eigenvalues_no_shm, V_no_shm, _ = jitted_syevd_no_shardmap(_A.copy(), T_A)
+    assert jnp.allclose(eigenvalues_expected, eigenvalues_no_shm)
+
+
+def cusolver_solve_psd(N, T_A, dtype):
+    A = random_psd(N, dtype=dtype, seed=1234)
+    eigenvalues_expected, V_expected = jnp.linalg.eigh(A)
+    # Make mesh and place data
+    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+    eigenvalues, V = jitted_syevd(_A.copy(), T_A)
+    norm_syevd = jnp.linalg.norm(V @ A - jnp.diag(eigenvalues) @ V.T)
+    norm_lax = jnp.linalg.norm(
+        V_expected @ A - jnp.diag(eigenvalues_expected) @ V_expected.T
+    )
+    assert jnp.isclose(norm_syevd, norm_lax, rtol=10, atol=1e-8)
+    eigenvalues_no_shm, V_no_shm, _ = jitted_syevd_no_shardmap(_A.copy(), T_A)
+    assert jnp.allclose(eigenvalues_expected, eigenvalues_no_shm, rtol=10, atol=1e-10)
+
+
+def cusolver_solve_arange_no_V(N, T_A, dtype):
+    A = jnp.diag(jnp.arange(N, dtype=dtype) + 1)
+    eigenvalues_expected = jnp.diag(A)
+    # Make mesh and place data
+    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+    eigenvalues = jitted_syevd_no_V(_A.copy(), T_A)
+    assert jnp.allclose(eigenvalues_expected, eigenvalues)
+    eigenvalues_no_shm, _ = jitted_syevd_no_V_no_shardmap(_A.copy(), T_A)
+    assert jnp.allclose(eigenvalues_expected, eigenvalues_no_shm)
+
+
+def cusolver_solve_psd_no_V(N, T_A, dtype):
+    A = random_psd(N, dtype=dtype, seed=1234)
+    eigenvalues_expected = jnp.linalg.eigvalsh(A)
+    # Make mesh and place data
+    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+    eigenvalues = jitted_syevd_no_V(_A.copy(), T_A)
+    assert jnp.allclose(eigenvalues, eigenvalues_expected, rtol=10, atol=0.0)
+    eigenvalues_no_shm, _ = jitted_syevd_no_V_no_shardmap(_A.copy(), T_A)
+    assert jnp.allclose(eigenvalues_expected, eigenvalues_no_shm, rtol=10, atol=0.0)
+
+
+def _build_registry() -> Dict[str, Callable]:
+    # Map test names to callables that accept (N, T_A, dtype)
+    return {
+        "arange": cusolver_solve_arange,
+        "psd": cusolver_solve_psd,
+        "arange_no_V": cusolver_solve_arange_no_V,
+        "psd_no_V": cusolver_solve_psd_no_V,
+    }
+
+
+def main(argv: List[str]):
+    # Single-task only: expect arguments
+    # run_syevd.py <coord_addr> <proc_id> <num_procs> <test_name> <dtype_name>
+
+    task_name = argv[4]
+    task_dtype_name = argv[5]
+    registry = _build_registry()
+
+    # Parameter grid metadata (for discover message)
+    ndev = len(devices)
+    dtypes = [jnp.float32, jnp.float64, jnp.complex64, jnp.complex128]
+    N_list = list(i * ndev for i in [2, 3, 4, 10])
+    T_A_list = [1, 2, 3, 5]
+    for task_N in N_list:
+        for task_T_A in T_A_list:
+            params_summary = {
+                "N": [task_N],
+                "T_A": [task_T_A],
+                "dtype": [task_dtype_name],
+            }
+
+            # Announce discovery for this single task
+            _println(
+                "MPTEST_DISCOVER",
+                {
+                    "proc": proc_id,
+                    "available": sorted(registry.keys()),
+                    "selected": [task_name],
+                    "params": params_summary,
+                },
+            )
+
+            fn = registry[task_name]
+            # Map dtype name to jnp dtype
+            dt = next(dt for dt in dtypes if jnp.dtype(dt).name == task_dtype_name)
+            n_ok = 0
+            n_fail = 0
+            try:
+                fn(task_N, task_T_A, dt)
+                _println(
+                    "MPTEST_RESULT",
+                    {
+                        "proc": proc_id,
+                        "name": task_name,
+                        "status": "ok",
+                        "params": {
+                            "N": task_N,
+                            "T_A": task_T_A,
+                            "dtype": task_dtype_name,
+                        },
+                    },
+                )
+                n_ok += 1
+            except Exception:
+                tb = traceback.format_exc(limit=40)
+                _println(
+                    "MPTEST_RESULT",
+                    {
+                        "proc": proc_id,
+                        "name": task_name,
+                        "status": "fail",
+                        "params": {
+                            "N": task_N,
+                            "T_A": task_T_A,
+                            "dtype": task_dtype_name,
+                        },
+                        "traceback": tb,
+                    },
+                )
+                n_fail += 1
+
+            _println(
+                "MPTEST_SUMMARY",
+                {"proc": proc_id, "ok": n_ok, "fail": n_fail, "total": n_ok + n_fail},
+            )
+            return 0
+
+
+main(sys.argv)

--- a/tests/mpmd/test_launch_potri.py
+++ b/tests/mpmd/test_launch_potri.py
@@ -6,7 +6,7 @@ import jax
 from mpmd_helper import run_mpmd_test
 
 HERE = Path(__file__).parent
-MP_TEST = HERE / "run_potrs.py"
+MP_TEST = HERE / "run_potri.py"
 
 if len(jax.devices("gpu")) == 0:
     pytest.skip("No GPUs found. Skipping")
@@ -24,8 +24,10 @@ if gpu_count == 0:
 # only for the local visible gpu count to keep collection stable.
 requested_procs_list = (gpu_count,)
 
+
 dtypes = ["float32", "float64", "complex64", "complex128"]
 test_names = ["arange", "non_psd", "non_symm", "psd"]
+
 
 tasks = []
 task_ids = []
@@ -41,7 +43,7 @@ for requested_procs in requested_procs_list:
     tasks,
     ids=task_ids,
 )
-def test_task_mpmd(requested_procs, name, dtype_name):
-    """Run a single distributed potrs task as an individual pytest test."""
+def test_task_mpmd_potri(requested_procs, name, dtype_name):
+    """Run a single distributed potri task as an individual pytest test."""
 
     run_mpmd_test(MP_TEST, requested_procs, name, dtype_name)

--- a/tests/mpmd/test_launch_syevd.py
+++ b/tests/mpmd/test_launch_syevd.py
@@ -6,7 +6,7 @@ import jax
 from mpmd_helper import run_mpmd_test
 
 HERE = Path(__file__).parent
-MP_TEST = HERE / "run_potrs.py"
+MP_TEST = HERE / "run_syevd.py"
 
 if len(jax.devices("gpu")) == 0:
     pytest.skip("No GPUs found. Skipping")
@@ -15,33 +15,33 @@ if len(jax.devices("gpu")) == 0:
 # Build the parameter grid once at collection time and parametrize each
 # (requested_procs, test_name, N, T_A, dtype) as a separate pytest test so
 # each task appears individually in pytest's summary.
-gpu_count = jax.device_count("gpu")
-if gpu_count == 0:
+GPU_COUNT = jax.device_count("gpu")
+if GPU_COUNT == 0:
     pytest.skip("No GPUs found. Skipping")
 
 # Only run for the currently visible GPU count; the original test enumerated
 # requested_procs=(1,2,3,4) and skipped when mismatched. Here we parametrize
 # only for the local visible gpu count to keep collection stable.
-requested_procs_list = (gpu_count,)
+REQUESTED_PROCS_LIST = (GPU_COUNT,)
 
-dtypes = ["float32", "float64", "complex64", "complex128"]
-test_names = ["arange", "non_psd", "non_symm", "psd"]
+DTYPES = ["float32", "float64", "complex64", "complex128"]
+TEST_NAMES = ["arange", "psd", "arange_no_V", "psd_no_V"]
 
-tasks = []
-task_ids = []
-for requested_procs in requested_procs_list:
-    for name in test_names:
-        for dtype_name in dtypes:
-            tasks.append((requested_procs, name, dtype_name))
-            task_ids.append(f"{name}-{dtype_name}-p{requested_procs}")
+TASKS = []
+TASK_IDS = []
+for requested_procs in REQUESTED_PROCS_LIST:
+    for name in TEST_NAMES:
+        for dtype_name in DTYPES:
+            TASKS.append((requested_procs, name, dtype_name))
+            TASK_IDS.append(f"{name}-{dtype_name}-p{requested_procs}")
 
 
 @pytest.mark.parametrize(
     "requested_procs,name, dtype_name",
-    tasks,
-    ids=task_ids,
+    TASKS,
+    ids=TASK_IDS,
 )
-def test_task_mpmd(requested_procs, name, dtype_name):
-    """Run a single distributed potrs task as an individual pytest test."""
+def test_task_mpmd_syevd(requested_procs, name, dtype_name):
+    """Run a single distributed syevd task as an individual pytest test."""
 
     run_mpmd_test(MP_TEST, requested_procs, name, dtype_name)


### PR DESCRIPTION
- There was a race condition happening for the Process barrier where processes could race ahead and open the shm before shm creator unlinked, leading to stale files and deadlocks. This is now solved with the new `close_and_wait()` method in process barrier that gets called at the end of each MP file and ensures that processes wait for shm to get unlinked.
- Implementations of `potri.cu`, `syevd.cu `and `syevd_mp.cu` are functional and tested in new tests under `tests/mpmd`.
- Small bug in the docs `col_maj.ipynb`.
- increased jenkins timeout so tests can run.