### PR TITLE
Fix inplace aliasing bug for potrs

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
                         CUDA_ROOT = '/usr/local/cuda'
                         CUDNN_ROOT = '/usr'
                         JAX_VERSION = '0.6.2'
+                        XLA_PYTHON_CLIENT_ALLOCATOR = 'platform'
                     }
                     steps {
                             sh '''#!/bin/bash -ex

--- a/src/cuda/potrs.cu
+++ b/src/cuda/potrs.cu
@@ -102,7 +102,9 @@ namespace jax
         ffi::Error PotrsMgImpl(int64_t N, int64_t NRHS, int64_t batch_a,
                                gpuStream_t stream, ffi::ScratchAllocator &scratch,
                                ffi::AnyBuffer a, ffi::AnyBuffer b, int64_t tile_size,
-                               ffi::Result<ffi::AnyBuffer> out, ffi::Result<ffi::Buffer<ffi::S32>> status)
+                               ffi::Result<ffi::AnyBuffer> out_a,
+                               ffi::Result<ffi::AnyBuffer> out_b, 
+                               ffi::Result<ffi::Buffer<ffi::S32>> status)
         {
             /* misc */
             const std::string &source = __FILE__; // file name for error messages
@@ -123,7 +125,8 @@ namespace jax
             /* data */
             auto array_data_A = static_cast<data_type *>(a.untyped_data()); // XLA device pointer for a
             auto array_data_b = static_cast<data_type *>(b.untyped_data());
-            auto out_data = static_cast<data_type *>(out->untyped_data());
+            auto out_data_a = static_cast<data_type *>(out_a->untyped_data());
+            auto out_data_b = static_cast<data_type *>(out_b->untyped_data());
 
             /* Tiling sizes */
             const int IA = 1; // index within a global matrix, base-1 (not used)
@@ -321,12 +324,13 @@ namespace jax
             // Collect solutions, fill nans if solver failed
             if (cusolver_status_host[currentDevice] == 0)
             {
-                JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(out_data, shmB[currentDevice], b.size_bytes(), gpuMemcpyDeviceToDevice));
+                out_data_a = shmA[currentDevice];
+                out_data_b = shmB[currentDevice];
             }
             else
             {
                 std::vector<typename traits<data_type>::T> host_nan(N * NRHS, traits<data_type>::nan());
-                JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(out_data, host_nan.data(), sizeof(data_type) * N * NRHS, gpuMemcpyHostToDevice));
+                JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(out_data_b, host_nan.data(), sizeof(data_type) * N * NRHS, gpuMemcpyHostToDevice));
             }
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
@@ -354,7 +358,9 @@ namespace jax
 
         ffi::Error PotrsMgDispatch(gpuStream_t stream, ffi::ScratchAllocator scratch,
                                    ffi::AnyBuffer a, ffi::AnyBuffer b, int64_t tile_size,
-                                   ffi::Result<ffi::AnyBuffer> out, ffi::Result<ffi::Buffer<ffi::S32>> status)
+                                   ffi::Result<ffi::AnyBuffer> out_a, 
+                                   ffi::Result<ffi::AnyBuffer> out_b, 
+                                   ffi::Result<ffi::Buffer<ffi::S32>> status)
         {
             auto dataType = a.element_type();
 
@@ -363,7 +369,12 @@ namespace jax
             FFI_ASSIGN_OR_RETURN((const auto [N_b, NRHS]), SplitBatch1D(b.dimensions()));
             FFI_RETURN_IF_ERROR(CheckShape(b.dimensions(), {N, NRHS}, "b", "potrf"));
 
-            if (dataType != out->element_type())
+            if (dataType != out_a->element_type())
+            {
+                return ffi::Error::InvalidArgument(
+                    "The input and output to potrs must have the same element type");
+            }
+            if (dataType != out_b->element_type())
             {
                 return ffi::Error::InvalidArgument(
                     "The input and output to potrs must have the same element type");
@@ -375,7 +386,7 @@ namespace jax
             }
             FFI_RETURN_IF_ERROR(CheckShape(status->dimensions(), 1, "status", "potrf"));
 
-            SOLVER_DISPATCH_IMPL(PotrsMgImpl, N, NRHS, batch_a, stream, scratch, a, b, tile_size, out, status);
+            SOLVER_DISPATCH_IMPL(PotrsMgImpl, N, NRHS, batch_a, stream, scratch, a, b, tile_size, out_a, out_b, status);
 
             return ffi::Error::InvalidArgument(absl::StrFormat(
                 "Unsupported data type%s for potrs", absl::FormatStreamed(dataType)));
@@ -388,7 +399,8 @@ namespace jax
                                           .Arg<ffi::AnyBuffer>()        // A
                                           .Arg<ffi::AnyBuffer>()        // b
                                           .Attr<int64_t>("T_A")         // tile size
-                                          .Ret<ffi::AnyBuffer>()        // x
+                                          .Ret<ffi::AnyBuffer>()        // A_out
+                                          .Ret<ffi::AnyBuffer>()        // b_out
                                           .Ret<ffi::Buffer<ffi::S32>>() // status
         );
 

--- a/src/cuda/potrs_mp.cu
+++ b/src/cuda/potrs_mp.cu
@@ -103,7 +103,9 @@ namespace jax
         ffi::Error PotrsMgImpl(int64_t N, int64_t NRHS, int64_t batch_a,
                                gpuStream_t stream, ffi::ScratchAllocator &scratch,
                                ffi::AnyBuffer a, ffi::AnyBuffer b, int64_t tile_size,
-                               ffi::Result<ffi::AnyBuffer> out, ffi::Result<ffi::Buffer<ffi::S32>> status)
+                               ffi::Result<ffi::AnyBuffer> out_a, 
+                               ffi::Result<ffi::AnyBuffer> out_b, 
+                               ffi::Result<ffi::Buffer<ffi::S32>> status)
         {
             /* misc */
             const std::string &source = __FILE__; // file name for error messages
@@ -125,7 +127,8 @@ namespace jax
             /* data */
             auto array_data_A = static_cast<data_type *>(a.untyped_data()); // XLA device pointer for a
             auto array_data_b = static_cast<data_type *>(b.untyped_data());
-            auto out_data = static_cast<data_type *>(out->untyped_data());
+            auto out_data_a = static_cast<data_type *>(out_a->untyped_data());
+            auto out_data_b = static_cast<data_type *>(out_b->untyped_data());
 
             /* Tiling sizes */
             const int IA = 1; // index within a global matrix, base-1 (not used)
@@ -169,8 +172,10 @@ namespace jax
             sharedMemoryInfo shminfo_offsetA;       // Shared memory info for offsets of A pointers
             sharedMemoryInfo shminfoBipc;           // Shared memory info for device pointers to b matrices
             sharedMemoryInfo shminfo_offsetB;       // Shared memory info for offsets of b pointers
-            sharedMemoryInfo shminfooutdataipc;     // Shared memory info for device pointers to out matrices
-            sharedMemoryInfo shminfo_offsetoutdata; // Shared memory info for offsets of out pointers
+            sharedMemoryInfo shminfooutdataaipc;     // Shared memory info for device pointers to out_a matrices
+            sharedMemoryInfo shminfooutdatabipc;     // Shared memory info for device pointers to out_b matrices
+            sharedMemoryInfo shminfo_offsetoutdataa; // Shared memory info for offsets of out_a pointers
+            sharedMemoryInfo shminfo_offsetoutdatab; // Shared memory info for offsets of out_b pointers
             sharedMemoryInfo shminfoworkipc;        // Shared memory info for workspace pointers
             sharedMemoryInfo shminfo_offsetwork;    // Shared memory info for offsets of workspace pointers
             sharedMemoryInfo shminfolwork;          // Shared memory info for lwork
@@ -186,11 +191,16 @@ namespace jax
             IpcOpenResult<data_type> opened_ptrs_B;
             cudaIpcMemHandle_t *shmBipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoBipc, "shmBipc");
             uintptr_t *shmoffsetB = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetB, "shmoffsetB");
-            // Data handles out_data
-            std::vector<data_type *> shmoutdata(nbGpus, nullptr);
-            IpcOpenResult<data_type> opened_ptrs_outdata;
-            cudaIpcMemHandle_t *shmoutdataipc = get_shm_ipc_handles(currentDevice, sync_point, shminfooutdataipc, "shmoutdataipc");
-            uintptr_t *shmoffsetoutdata = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetoutdata, "shmoffsetoutdata");
+            // Data handles out_data_a
+            std::vector<data_type *> shmoutdataa(nbGpus, nullptr);
+            IpcOpenResult<data_type> opened_ptrs_outdataa;
+            cudaIpcMemHandle_t *shmoutdataaipc = get_shm_ipc_handles(currentDevice, sync_point, shminfooutdataaipc, "shmoutdataaipc");
+            uintptr_t *shmoffsetoutdataa = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetoutdataa, "shmoffsetoutdataa");
+            // Data handles out_data_b
+            std::vector<data_type *> shmoutdatab(nbGpus, nullptr);
+            IpcOpenResult<data_type> opened_ptrs_outdatab;
+            cudaIpcMemHandle_t *shmoutdatabipc = get_shm_ipc_handles(currentDevice, sync_point, shminfooutdatabipc, "shmoutdatabipc");
+            uintptr_t *shmoffsetoutdatab = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetoutdatab, "shmoffsetoutdatab");
             // Data handles shmwork
             std::vector<data_type *> shmwork(nbGpus, nullptr);
             IpcOpenResult<data_type> opened_ptrs_work;
@@ -234,7 +244,8 @@ namespace jax
             sync_point.arrive_and_wait();
             ipcGetHandleAndOffset(array_data_A, shmAipc[currentDevice], shmoffsetA[currentDevice]);
             ipcGetHandleAndOffset(array_data_b, shmBipc[currentDevice], shmoffsetB[currentDevice]);
-            ipcGetHandleAndOffset(out_data, shmoutdataipc[currentDevice], shmoffsetoutdata[currentDevice]);
+            ipcGetHandleAndOffset(out_data_a, shmoutdataaipc[currentDevice], shmoffsetoutdataa[currentDevice]);
+            ipcGetHandleAndOffset(out_data_b, shmoutdatabipc[currentDevice], shmoffsetoutdatab[currentDevice]);
 
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
@@ -244,17 +255,20 @@ namespace jax
             {
                 opened_ptrs_A = ipcGetDevicePointers<data_type>(currentDevice, nbGpus, shmAipc, shmoffsetA);
                 opened_ptrs_B = ipcGetDevicePointers<data_type>(currentDevice, nbGpus, shmBipc, shmoffsetB);
-                opened_ptrs_outdata = ipcGetDevicePointers<data_type>(currentDevice, nbGpus, shmoutdataipc, shmoffsetoutdata);
+                opened_ptrs_outdataa = ipcGetDevicePointers<data_type>(currentDevice, nbGpus, shmoutdataaipc, shmoffsetoutdatab);
+                opened_ptrs_outdatab = ipcGetDevicePointers<data_type>(currentDevice, nbGpus, shmoutdatabipc, shmoffsetoutdatab);
 
                 for (int dev = 1; dev < nbGpus; ++dev)
                 {
                     shmA[dev] = opened_ptrs_A.ptrs[dev];
                     shmB[dev] = opened_ptrs_B.ptrs[dev];
-                    shmoutdata[dev] = opened_ptrs_outdata.ptrs[dev];
+                    shmoutdataa[dev] = opened_ptrs_outdataa.ptrs[dev];
+                    shmoutdatab[dev] = opened_ptrs_outdatab.ptrs[dev];
                 }
                 shmA[0] = array_data_A;
                 shmB[0] = array_data_b;
-                shmoutdata[0] = out_data;
+                shmoutdataa[0] = out_data_a;
+                shmoutdatab[0] = out_data_b;
             }
 
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
@@ -376,16 +390,20 @@ namespace jax
             {
                 for (int dev = 0; dev < nbGpus; dev++)
                 {
-                    JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(shmoutdata[dev], shmB[0], b.size_bytes(), gpuMemcpyDeviceToDevice));
+                    JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(shmoutdatab[dev], shmB[0], b.size_bytes(), gpuMemcpyDeviceToDevice));
                 }
             }
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
+            // Set output pointers for A
+            if (cusolver_status_host[currentDevice] == 0){
+                shmoutdataa[currentDevice] = shmA[currentDevice];
+            }
             // Fill nans if solver failed
-            if (cusolver_status_host[currentDevice] != 0)
+            else
             {
                 std::vector<typename traits<data_type>::T> host_nan(N * NRHS, traits<data_type>::nan());
-                JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(out_data, host_nan.data(), sizeof(data_type) * N * NRHS, gpuMemcpyHostToDevice));
+                JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(out_data_b, host_nan.data(), sizeof(data_type) * N * NRHS, gpuMemcpyHostToDevice));
             }
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
@@ -403,8 +421,10 @@ namespace jax
                 sharedMemoryCleanup(&shminfoAipc, "shmAipc");
                 sharedMemoryCleanup(&shminfo_offsetB, "shmoffsetB");
                 sharedMemoryCleanup(&shminfoBipc, "shmBipc");
-                sharedMemoryCleanup(&shminfo_offsetoutdata, "shmoffsetoutdata");
-                sharedMemoryCleanup(&shminfooutdataipc, "shmoutdataipc");
+                sharedMemoryCleanup(&shminfo_offsetoutdataa, "shmoffsetoutdataa");
+                sharedMemoryCleanup(&shminfo_offsetoutdatab, "shmoffsetoutdatab");
+                sharedMemoryCleanup(&shminfooutdatabipc, "shmoutdataaipc");
+                sharedMemoryCleanup(&shminfooutdatabipc, "shmoutdatabipc");
                 sharedMemoryCleanup(&shminfoworkipc, "shmworkipc");
                 sharedMemoryCleanup(&shminfo_offsetwork, "shmoffsetwork");
                 sharedMemoryCleanup(&shminfolwork, "shmlwork");
@@ -412,7 +432,8 @@ namespace jax
                 // Close memory handles
                 ipcCloseDevicePointers(currentDevice, opened_ptrs_A.bases, nbGpus);
                 ipcCloseDevicePointers(currentDevice, opened_ptrs_B.bases, nbGpus);
-                ipcCloseDevicePointers(currentDevice, opened_ptrs_outdata.bases, nbGpus);
+                ipcCloseDevicePointers(currentDevice, opened_ptrs_outdataa.bases, nbGpus);
+                ipcCloseDevicePointers(currentDevice, opened_ptrs_outdatab.bases, nbGpus);
                 workspaceFree(nbGpus, deviceList.data(), reinterpret_cast<void **>(shmwork.data()));
             }
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
@@ -423,7 +444,9 @@ namespace jax
 
         ffi::Error PotrsMgDispatch(gpuStream_t stream, ffi::ScratchAllocator scratch,
                                    ffi::AnyBuffer a, ffi::AnyBuffer b, int64_t tile_size,
-                                   ffi::Result<ffi::AnyBuffer> out, ffi::Result<ffi::Buffer<ffi::S32>> status)
+                                   ffi::Result<ffi::AnyBuffer> out_a,
+                                   ffi::Result<ffi::AnyBuffer> out_b,
+                                    ffi::Result<ffi::Buffer<ffi::S32>> status)
         {
             auto dataType = a.element_type();
 
@@ -432,7 +455,12 @@ namespace jax
             FFI_ASSIGN_OR_RETURN((const auto [N_b, NRHS]), SplitBatch1D(b.dimensions()));
             FFI_RETURN_IF_ERROR(CheckShape(b.dimensions(), {N, NRHS}, "b", "potrf"));
 
-            if (dataType != out->element_type())
+            if (dataType != out_a->element_type())
+            {
+                return ffi::Error::InvalidArgument(
+                    "The input and output to potrs must have the same element type");
+            }
+            if (dataType != out_b->element_type())
             {
                 return ffi::Error::InvalidArgument(
                     "The input and output to potrs must have the same element type");
@@ -444,7 +472,7 @@ namespace jax
             }
             FFI_RETURN_IF_ERROR(CheckShape(status->dimensions(), 1, "status", "potrf"));
 
-            SOLVER_DISPATCH_IMPL(PotrsMgImpl, N, NRHS, batch_a, stream, scratch, a, b, tile_size, out, status);
+            SOLVER_DISPATCH_IMPL(PotrsMgImpl, N, NRHS, batch_a, stream, scratch, a, b, tile_size, out_a,out_b, status);
 
             return ffi::Error::InvalidArgument(absl::StrFormat(
                 "Unsupported data type%s for potrs", absl::FormatStreamed(dataType)));
@@ -457,7 +485,8 @@ namespace jax
                                           .Arg<ffi::AnyBuffer>()        // A
                                           .Arg<ffi::AnyBuffer>()        // b
                                           .Attr<int64_t>("T_A")         // tile size
-                                          .Ret<ffi::AnyBuffer>()        // x
+                                          .Ret<ffi::AnyBuffer>()        // A_out
+                                          .Ret<ffi::AnyBuffer>()        // b_out
                                           .Ret<ffi::Buffer<ffi::S32>>() // status
         );
 

--- a/src/jaxmg/_potrs.py
+++ b/src/jaxmg/_potrs.py
@@ -17,7 +17,7 @@ def potrs(
     b: Array,
     T_A: int,
     mesh: Mesh,
-    in_specs: Tuple[P,P] | List[P],
+    in_specs: Tuple[P, P] | List[P],
     return_status: bool = False,
     pad=True,
 ) -> Union[Array, Tuple[Array, int]]:
@@ -31,9 +31,9 @@ def potrs(
     Tip:
         If the shards of the matrix cannot be padded with tiles of size `T_A`
         (``N / num_gpus % T_A != 0``) we have to add padding to fit the last tile.
-        This requires copying the matrix, which we want to avoid at all costs for 
+        This requires copying the matrix, which we want to avoid at all costs for
         large ``N``. Make sure you pick ``T_A`` large enough (>=128) and such that it
-        can evenly cover the shards. In principle, increasing ``T_A`` will increase 
+        can evenly cover the shards. In principle, increasing ``T_A`` will increase
         performance at the cost of memory, but depending on ``N``, the performance
           will saturate.
 
@@ -43,10 +43,10 @@ def potrs(
             using a single ``PartitionSpec``: ``P(<axis_name>, None)``.
         b (Array): 2D right-hand side. Expected to be replicated across
             devices with ``PartitionSpec`` ``P(None, None)``.
-        T_A (int): Tile width used by the native solver. Each 
-            local shard length must be a multiple of ``T_A``. If the user provides a 
+        T_A (int): Tile width used by the native solver. Each
+            local shard length must be a multiple of ``T_A``. If the user provides a
             ``T_A`` that is incompatible with the shard size we pad the matrix
-            accordingly. For small tile sizes (``T_A``< 128), the solver can 
+            accordingly. For small tile sizes (``T_A``< 128), the solver can
             be extremely slow, so ensure that ``T_A`` is large enough. In principle,
             the larger ``T_A`` the faster the solver runs.
         mesh (Mesh): JAX Mesh object used for ``jax.shard_map``.
@@ -101,14 +101,36 @@ def potrs(
     assert b.ndim == 2, "b must be a 2D array."
     N_rows, N = a.shape
     axis_name = spec_a._partitions[0]
+
     shard_size = N_rows // ndev
 
     # Keep b in column-major layout
     input_layouts = ((0, 1), (1, 0))
-    output_layouts = ((1, 0), (0,))
+    output_layouts = ((0, 1), (1, 0), (0,))
 
     padding = calculate_padding(shard_size, T_A)
+
+    if not pad or padding == 0 or T_A >= N // ndev:
+        if T_A < N // ndev:
+            assert (
+                N_rows == N + ndev * padding
+            ), f"pad=False, but with T_A={T_A}, we need padding of {padding} rows per device."
+            f"Expected {N + ndev * padding} rows, but received {N_rows}"
+        # Identity padding
+        pad_fn = lambda _a: _a
+        padding = 0
+    else:
+        # Make padding fns
+        pad_fn = jax.shard_map(
+            partial(pad_rows, padding=padding),
+            mesh=mesh,
+            in_specs=P(axis_name, None),
+            out_specs=P(axis_name, None),
+            check_vma=True,
+        )
+
     out_type = (
+        jax.ShapeDtypeStruct((shard_size + padding, N), a.dtype),
         jax.ShapeDtypeStruct(b.shape, b.dtype),
         jax.ShapeDtypeStruct((1,), jnp.int32),
     )
@@ -120,48 +142,31 @@ def potrs(
             out_type,
             input_layouts=input_layouts,
             output_layouts=output_layouts,
+            input_output_aliases={0: 0, 1: 1},
         ),
         T_A=T_A,
     )
 
     # Jit with donate_argnums=0 is crucial for buffer sharing
-    @partial(jax.jit, donate_argnums=0)
+    @partial(jax.jit, donate_argnums=(0, 1))
     @partial(
         jax.shard_map,
         mesh=mesh,
         in_specs=(P(axis_name, None), P(None, None)),
-        out_specs=(P(None, None), P(None)),
+        out_specs=(P(axis_name, None), P(None, None), P(None)),
         check_vma=False,
     )
     def impl(_a, _b):
-        _a, _status = ffi_fn(_a, _b) 
-        return _a, _status
-
-    if not pad or padding == 0 or T_A >= N // ndev:
-        if T_A < N // ndev:
-            assert (
-                N_rows == N + ndev * padding
-            ), f"pad=False, but with T_A={T_A}, we need padding of {padding} rows per device."
-            f"Expected {N + ndev * padding} rows, but received {N_rows}"
-        # Identity padding
-        pad_fn = lambda _a: _a
-
-    else:
-        # Make padding fns
-        pad_fn = jax.shard_map(
-            partial(pad_rows, padding=padding),
-            mesh=mesh,
-            in_specs=P(axis_name, None),
-            out_specs=P(axis_name, None),
-            check_vma=True,
-        )
+        _a = _a.conj()
+        _out_a, _out_b, _status = ffi_fn(_a, _b)
+        return _out_a, _out_b, _status
 
     def fn(_a, _b):
         _a = pad_fn(_a)
-        _out, _status = impl(_a, _b)
-        return _out, _status
+        _out_a, _out_b, _status = impl(_a, _b)
+        return _out_b, _status
 
-    out, status = fn(a.conj(), b)
+    out, status = fn(a, b)
     if return_status:
         return out, status[0]
     else:
@@ -175,16 +180,16 @@ def potrs_shardmap_ctx(a: Array, b: Array, T_A: int, pad=True) -> Tuple[Array, A
     for contexts where the input ``a`` is already laid out and sharded at the
     application level (for example when running inside a custom
     ``shard_map``/pjit-managed context). It performs the same padding logic
-    driven by ``T_A`` and directly calls the native ``potrs_mg`` FFI targets 
+    driven by ``T_A`` and directly calls the native ``potrs_mg`` FFI targets
     via ``jax.ffi.ffi_call`` instead of constructing an additional ``shard_map``
     wrapper.
 
     Tip:
         If the shards of the matrix cannot be padded with tiles of size `T_A`
         (``N / num_gpus % T_A != 0``) we have to add padding to fit the last tile.
-        This requires copying the matrix, which we want to avoid at all costs for 
+        This requires copying the matrix, which we want to avoid at all costs for
         large ``N``. Make sure you pick ``T_A`` large enough (>=128) and such that it
-        can evenly cover the shards. In principle, increasing ``T_A`` will increase 
+        can evenly cover the shards. In principle, increasing ``T_A`` will increase
         performance at the cost of memory, but depending on ``N``, the performance
           will saturate.
 
@@ -193,10 +198,10 @@ def potrs_shardmap_ctx(a: Array, b: Array, T_A: int, pad=True) -> Tuple[Array, A
             symmetric for correct solver behavior.
         b (Array): 2D right-hand side. Its first dimension must equal the
             number of columns of ``a`` (i.e. ``a.shape[1] == b.shape[0]``).
-        T_A (int): Tile width used by the native solver. Each 
-            local shard length must be a multiple of ``T_A``. If the user provides a 
+        T_A (int): Tile width used by the native solver. Each
+            local shard length must be a multiple of ``T_A``. If the user provides a
             ``T_A`` that is incompatible with the shard size we pad the matrix
-            accordingly. For small tile sizes (``T_A``< 128), the solver can 
+            accordingly. For small tile sizes (``T_A``< 128), the solver can
             be extremely slow, so ensure that ``T_A`` is large enough. In principle,
             the larger ``T_A`` the faster the solver runs.
         pad (bool, optional): If True (default) apply per-device padding to
@@ -227,10 +232,26 @@ def potrs_shardmap_ctx(a: Array, b: Array, T_A: int, pad=True) -> Tuple[Array, A
 
     # Keep b in column-major layout
     input_layouts = ((0, 1), (1, 0))
-    output_layouts = ((1, 0), (0,))
+    output_layouts = ((0, 1), (1, 0), (0,))
 
     padding = calculate_padding(shard_size, T_A)
+
+    if not pad or padding == 0 or T_A >= N // ndev:
+        if T_A < N // ndev:
+            assert (
+                shard_size == (N + ndev * padding) // ndev
+            ), f"pad=False, but with T_A={T_A}, we need padding of {padding} rows per device."
+            f"Expected {N + ndev * padding} rows, but received {shard_size}"
+        # Identity padding
+        pad_fn = lambda _a: _a
+        padding = 0
+
+    else:
+        # Make padding fns
+        pad_fn = partial(pad_rows, padding=padding)
+
     out_type = (
+        jax.ShapeDtypeStruct((shard_size + padding, N), a.dtype),
         jax.ShapeDtypeStruct(b.shape, b.dtype),
         jax.ShapeDtypeStruct((1,), jnp.int32),
     )
@@ -242,31 +263,20 @@ def potrs_shardmap_ctx(a: Array, b: Array, T_A: int, pad=True) -> Tuple[Array, A
             out_type,
             input_layouts=input_layouts,
             output_layouts=output_layouts,
+            input_output_aliases={0: 0, 1: 1},
         ),
         T_A=T_A,
     )
 
     # Jit with donate_argnums=0 is crucial for buffer sharing
     def impl(_a, _b):
-        _a, _status = ffi_fn(_a, _b)
-        return _a, _status
-
-    if not pad or padding == 0 or T_A >= N // ndev:
-        if T_A < N // ndev:
-            assert (
-                shard_size == (N + ndev * padding) // ndev
-            ), f"pad=False, but with T_A={T_A}, we need padding of {padding} rows per device."
-            f"Expected {N + ndev * padding} rows, but received {shard_size}"
-        # Identity padding
-        pad_fn = lambda _a: _a
-
-    else:
-        # Make padding fns
-        pad_fn = partial(pad_rows, padding=padding)
+        _a = _a.conj()
+        _out_a, _out_b, _status = ffi_fn(_a, _b)
+        return _out_b, _status
 
     def fn(_a, _b):
         _a = pad_fn(_a)
         _out, _status = impl(_a, _b)
         return _out, _status
 
-    return fn(a.conj(), b)
+    return fn(a, b)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,10 +3,10 @@ def pytest_collection_modifyitems(config, items):
     deselected = []
     for item in items:
         selected.append(item)
-        # if "mpmd/test_launch_potrs.py" in item.nodeid:
-        #     selected.append(item)
-        # else:
-        #     deselected.append(item)
+        if "mpmd/test_launch_2d_grid_reduce.py" in item.nodeid:
+            selected.append(item)
+        else:
+            deselected.append(item)
     if deselected:
         config.hook.pytest_deselected(items=deselected)
     items[:] = selected

--- a/tests/spmd/test_potri.py
+++ b/tests/spmd/test_potri.py
@@ -141,3 +141,22 @@ def test_cusolver_solve_non_psd_dev_1(N, T_A, dtype):
 @pytest.mark.parametrize("N", N_list)
 def test_cusolver_solve_non_symm_dev_1(N, T_A, dtype):
     cusolver_solve_non_symm(N, T_A, dtype)
+
+
+@pytest.mark.parametrize(
+    "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
+)
+def test_cusolver_inplace_check(dtype):
+    N = ndev * 2
+    T_A = 1
+    A = random_psd(N, dtype=dtype, seed=1234)
+    expected_out = jnp.linalg.inv(A)
+    # Make mesh and place data
+    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+    A_inv = jitted_potri(_A, T_A)
+    norm_potri = jnp.linalg.norm(A @ A_inv - jnp.eye(N, dtype=dtype))
+    norm_lax = jnp.linalg.norm(A @ expected_out - jnp.eye(N, dtype=dtype))
+    assert jnp.isclose(norm_potri, norm_lax, rtol=10, atol=1e-8)
+    A_inv = jitted_potri(_A, T_A)
+    norm_potri = jnp.linalg.norm(A @ A_inv - jnp.eye(N, dtype=dtype))
+    assert jnp.isclose(norm_potri, norm_lax, rtol=10, atol=1e-8)

--- a/tests/spmd/test_potrs.py
+++ b/tests/spmd/test_potrs.py
@@ -151,3 +151,22 @@ def test_cusolver_solve_non_psd(N, T_A, dtype):
 @pytest.mark.parametrize("N", N_list)
 def test_cusolver_solve_non_symm(N, T_A, dtype):
     cusolver_solve_non_symm(N, T_A, dtype)
+
+@pytest.mark.parametrize(
+    "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
+)
+def test_cusolver_inplace_check(dtype):
+    N = ndev * 2
+    T_A = 1
+    A = random_psd(N, dtype=dtype, seed=1234)
+    b = jnp.ones((N, 1), dtype=dtype)
+    cfac = jax.scipy.linalg.cho_factor(A)
+    expected_out = jax.scipy.linalg.cho_solve(cfac, b)
+    # Make mesh and place data
+    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+    _b = jax.device_put(b, NamedSharding(mesh, P(None, None)))
+
+    out = jitted_potrs(_A, _b, T_A)
+    assert jnp.allclose(out, expected_out, atol=1e-4)
+    out = jitted_potrs(_A, _b, T_A)
+    assert jnp.allclose(out, expected_out, atol=1e-4)

--- a/tests/spmd/test_syevd.py
+++ b/tests/spmd/test_syevd.py
@@ -151,3 +151,18 @@ def test_cusolver_solve_arange_no_v(N, T_A, dtype):
 @pytest.mark.parametrize("N", N_list)
 def test_cusolver_solve_psd_no_v(N, T_A, dtype):
     cusolver_solve_psd_no_V(N, T_A, dtype)
+
+@pytest.mark.parametrize(
+    "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
+)
+def test_cusolver_inplace_check(dtype):
+    N = ndev * 2
+    T_A = 1
+    A = random_psd(N, dtype=dtype, seed=1234)
+    # Make mesh and place data
+    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+    expected = jnp.linalg.eigvalsh(A)
+    eigenvalues, _ = jitted_syevd(_A, T_A)
+    assert jnp.allclose(expected, eigenvalues, atol=1e-4)
+    eigenvalues, _ = jitted_syevd(_A, T_A)
+    assert jnp.allclose(expected, eigenvalues, atol=1e-4)


### PR DESCRIPTION
As described in #11, `potrs` does in-place mutations leading to silent differences in the underlying matrices.

This is now tested for with new tests for each function.

The fix was returning the actual underlying matrix even when it is being changed and pass input_output_aliases={0: 0, 1: 1} to enable jax to handle the aliasing under jit.

