### PR TITLE
Fix File Descriptor Leak and potrs shapes.

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -150,7 +150,7 @@ pipeline {
                                                     killgpu
                                                     source "$WORKDIR/venv/bin/activate"
                                                     python -m pip install pytest matplotlib
-                                                    python -m pytest -svv tests
+                                                    python -m pytest -svv -m 'not mpmd' tests
                                                 '''
                                             }
                                         }
@@ -250,7 +250,8 @@ pipeline {
                                     //             python -m pytest -svv tests
                                     //         '''
                                     //     }
-                                    // }
+                                    // } python -m pytest -svv tests
+
                                     }
                                 }
                             }

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -150,13 +150,13 @@ pipeline {
                                         }
                                         stage("Test ${c}-${p}-${j}") {
                                             withEnv(["WORKDIR=${c}/${p}/${j}"]) {
-                                                sh '''#!/bin/bash -ex
+                                                sh """#!/bin/bash -ex
                                                     source .jenkins/scripts/gpu_utils.sh
                                                     killgpu
                                                     source "$WORKDIR/venv/bin/activate"
                                                     python -m pip install pytest matplotlib
-                                                    $pytest_cmd
-                                                '''
+                                                    ${pytest_cmd}
+                                                """
                                             }
                                         }
                                     }

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -106,6 +106,11 @@ pipeline {
                                             echo "Skipping ${c}-${p}-${j}: python 3.14 with JAX 0.6.2 unsupported"
                                             continue
                                         }
+                                        if (p == '3.11' && j == '0.6.2') {
+                                            pytest_cmd = "python -m pytest -svv tests"
+                                        } else {
+                                            pytest_cmd = "python -m pytest -svv -m 'not mpmd' tests"
+                                        }
                                         stage("Build ${c}-${p}-${j}") {
                                             unstash 'bin12'
                                             unstash 'bin13'
@@ -150,7 +155,7 @@ pipeline {
                                                     killgpu
                                                     source "$WORKDIR/venv/bin/activate"
                                                     python -m pip install pytest matplotlib
-                                                    python -m pytest -svv -m 'not mpmd' tests
+                                                    $pytest_cmd
                                                 '''
                                             }
                                         }

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ The provided binaries are compiled with
 | `cuda12`,`cuda12-local` | 12.8.0 | 9.17.1.4|
 | `cuda13`,`cuda13-local` | 13.0.0 | 9.17.1.4|
 
+Details for compiling the from source code can be found in `CONTRIBUTING.md`.
+
 > **_Note:_** `pip install jaxmg` will install a CPU-only version of JAX. Since `jaxmg` is a GPU-only package you will receive a warning to install a GPU-compatible version of jax. 
 
 ## Example

--- a/src/cuda/potri.cu
+++ b/src/cuda/potri.cu
@@ -153,11 +153,11 @@ namespace jax
             sharedMemoryInfo shminfolwork; // Shared memory info for lwork space nbytes
             sharedMemoryInfo shmcsh;       // Shared memory info for cusolver status
 
-            data_type **shmA = get_shm_device_ptrs<data_type>(currentDevice, sync_point, shminfoA, "shmA"); // Actual shared memory
-            data_type **shmwork = get_shm_device_ptrs<data_type>(currentDevice, sync_point, shminfowork, "shmwork");
+            data_type **shmA = get_shm_device_ptrs<data_type>(currentDevice, sync_point, shminfoA, "jaxmg_shmA"); // Actual shared memory
+            data_type **shmwork = get_shm_device_ptrs<data_type>(currentDevice, sync_point, shminfowork, "jaxmg_shmwork");
 
-            int32_t *cusolver_status_host = get_shm_lwork_ptr<int32_t, ThreadBarrier>(currentDevice, sync_point, shmcsh, "shmcsh");
-            int64_t *shmlwork = get_shm_lwork_ptr<int64_t, ThreadBarrier>(currentDevice, sync_point, shminfolwork, "shmlwork");
+            int32_t *cusolver_status_host = get_shm_lwork_ptr<int32_t, ThreadBarrier>(currentDevice, sync_point, shmcsh, "jaxmg_shmcsh");
+            int64_t *shmlwork = get_shm_lwork_ptr<int64_t, ThreadBarrier>(currentDevice, sync_point, shminfolwork, "jaxmg_shmlwork");
 
             if (currentDevice == 0)
             {
@@ -297,6 +297,12 @@ namespace jax
             }
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
+            // Close file descriptors
+            sharedMemoryClose(&shminfoA);
+            sharedMemoryClose(&shminfowork);
+            sharedMemoryClose(&shmcsh);
+            sharedMemoryClose(&shminfolwork);
+            sync_point.arrive_and_wait();
             if (currentDevice == 0)
             {
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyMatrixDesc(descrA));
@@ -304,11 +310,11 @@ namespace jax
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyGrid(gridA));
 
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroy(cusolverH));
-
-                sharedMemoryCleanup(&shminfoA, "shmA");
-                sharedMemoryCleanup(&shminfowork, "shmwork");
-                sharedMemoryCleanup(&shminfolwork, "shmcsh");
-                sharedMemoryCleanup(&shmcsh, "shmlwork");
+                // Unlink file descriptors
+                sharedMemoryUnlink("jaxmg_shmA");
+                sharedMemoryUnlink("jaxmg_shmwork");
+                sharedMemoryUnlink("jaxmg_shmcsh");
+                sharedMemoryUnlink("jaxmg_shmlwork");
             }
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();

--- a/src/cuda/potri_mp.cu
+++ b/src/cuda/potri_mp.cu
@@ -162,23 +162,23 @@ namespace jax
             // Data handles A
             std::vector<data_type *> shmA(nbGpus, nullptr);
             IpcOpenResult<data_type> opened_ptrs_A;
-            cudaIpcMemHandle_t *shmAipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoAipc, "shmAipc");
-            uintptr_t *shmoffsetA = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetA, "shmoffsetA");
+            cudaIpcMemHandle_t *shmAipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoAipc, "jaxmg_shmAipc");
+            uintptr_t *shmoffsetA = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetA, "jaxmg_shmoffsetA");
 
             // Data handles out_data
             std::vector<data_type *> shmoutdata(nbGpus, nullptr);
             IpcOpenResult<data_type> opened_ptrs_outdata;
-            cudaIpcMemHandle_t *shmoutdataipc = get_shm_ipc_handles(currentDevice, sync_point, shminfooutdataipc, "shmoutdataipc");
-            uintptr_t *shmoffsetoutdata = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetoutdata, "shmoffsetoutdata");
+            cudaIpcMemHandle_t *shmoutdataipc = get_shm_ipc_handles(currentDevice, sync_point, shminfooutdataipc, "jaxmg_shmoutdataipc");
+            uintptr_t *shmoffsetoutdata = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetoutdata, "jaxmg_shmoffsetoutdata");
 
             // Data handles workspace
             std::vector<data_type *> shmwork(nbGpus, nullptr);
             IpcOpenResult<data_type> opened_ptrs_work;
-            cudaIpcMemHandle_t *shmworkipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoworkipc, "shmworkipc");
-            uintptr_t *shmoffsetwork = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetwork, "shmoffsetwork");
+            cudaIpcMemHandle_t *shmworkipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoworkipc, "jaxmg_shmworkipc");
+            uintptr_t *shmoffsetwork = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetwork, "jaxmg_shmoffsetwork");
 
-            int32_t *cusolver_status_host = get_shm_lwork_ptr<int32_t>(currentDevice, sync_point, shminfo_csh, "shmcsh");
-            int64_t *shmlwork = get_shm_lwork_ptr<int64_t>(currentDevice, sync_point, shminfolwork, "shmlwork");
+            int32_t *cusolver_status_host = get_shm_lwork_ptr<int32_t>(currentDevice, sync_point, shminfo_csh, "jaxmg_shmcsh");
+            int64_t *shmlwork = get_shm_lwork_ptr<int64_t>(currentDevice, sync_point, shminfolwork, "jaxmg_shmlwork");
 
             if (currentDevice == 0)
             {
@@ -354,7 +354,16 @@ namespace jax
             }
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
-
+            // Close file descriptors
+            sharedMemoryClose(&shminfo_offsetA);
+            sharedMemoryClose(&shminfoAipc);
+            sharedMemoryClose(&shminfo_offsetoutdata);
+            sharedMemoryClose(&shminfooutdataipc);
+            sharedMemoryClose(&shminfoworkipc);
+            sharedMemoryClose(&shminfo_offsetwork);
+            sharedMemoryClose(&shminfolwork);
+            sharedMemoryClose(&shminfo_csh);
+            sync_point.arrive_and_wait();
             if (currentDevice == 0)
             {
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyMatrixDesc(descrA));
@@ -362,15 +371,15 @@ namespace jax
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyGrid(gridA));
 
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroy(cusolverH));
-                // Shared memory close
-                sharedMemoryCleanup(&shminfo_offsetA, "shmoffsetA");
-                sharedMemoryCleanup(&shminfoAipc, "shmAipc");
-                sharedMemoryCleanup(&shminfo_offsetoutdata, "shmoffsetoutdata");
-                sharedMemoryCleanup(&shminfooutdataipc, "shmoutdataipc");
-                sharedMemoryCleanup(&shminfoworkipc, "shmworkipc");
-                sharedMemoryCleanup(&shminfo_offsetwork, "shmoffsetwork");
-                sharedMemoryCleanup(&shminfolwork, "shmlwork");
-                sharedMemoryCleanup(&shminfo_csh, "shmcsh");
+                // Shared memory unlink
+                sharedMemoryUnlink("jaxmg_shmoffsetA");
+                sharedMemoryUnlink("jaxmg_shmAipc");
+                sharedMemoryUnlink("jaxmg_shmoffsetoutdata");
+                sharedMemoryUnlink("jaxmg_shmoutdataipc");
+                sharedMemoryUnlink("jaxmg_shmworkipc");
+                sharedMemoryUnlink("jaxmg_shmoffsetwork");
+                sharedMemoryUnlink("jaxmg_shmlwork");
+                sharedMemoryUnlink("jaxmg_shmcsh");
                 // Close memory handles
                 ipcCloseDevicePointers(currentDevice, opened_ptrs_A.bases, nbGpus);
                 ipcCloseDevicePointers(currentDevice, opened_ptrs_outdata.bases, nbGpus);

--- a/src/cuda/potrs.cu
+++ b/src/cuda/potrs.cu
@@ -173,12 +173,12 @@ namespace jax
             sharedMemoryInfo shminfolwork; // Shared memory info for lwork space nbytes
             sharedMemoryInfo shmcsh;       // Shared memory info for cusolver status
 
-            data_type **shmA = get_shm_device_ptrs<data_type>(currentDevice, sync_point, shminfoA, "shmA"); // Actual shared memory
-            data_type **shmB = get_shm_device_ptrs<data_type>(currentDevice, sync_point, shminfoB, "shmB");
-            data_type **shmwork = get_shm_device_ptrs<data_type>(currentDevice, sync_point, shminfowork, "shmwork");
+            data_type **shmA = get_shm_device_ptrs<data_type>(currentDevice, sync_point, shminfoA, "jaxmg_shmA"); // Actual shared memory
+            data_type **shmB = get_shm_device_ptrs<data_type>(currentDevice, sync_point, shminfoB, "jaxmg_shmB");
+            data_type **shmwork = get_shm_device_ptrs<data_type>(currentDevice, sync_point, shminfowork, "jaxmg_shmwork");
 
-            int32_t *cusolver_status_host = get_shm_lwork_ptr<int32_t, ThreadBarrier>(currentDevice, sync_point, shmcsh, "shmcsh");
-            int64_t *shmlwork = get_shm_lwork_ptr<int64_t, ThreadBarrier>(currentDevice, sync_point, shminfolwork, "shmlwork");
+            int32_t *cusolver_status_host = get_shm_lwork_ptr<int32_t, ThreadBarrier>(currentDevice, sync_point, shmcsh, "jaxmg_shmcsh");
+            int64_t *shmlwork = get_shm_lwork_ptr<int64_t, ThreadBarrier>(currentDevice, sync_point, shminfolwork, "jaxmg_shmlwork");
 
             if (currentDevice == 0)
             {
@@ -334,21 +334,26 @@ namespace jax
             }
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
+            // Close file descriptors
+            sharedMemoryClose(&shminfoA);
+            sharedMemoryClose(&shminfoB);
+            sharedMemoryClose(&shminfowork);
+            sharedMemoryClose(&shmcsh);
+            sharedMemoryClose(&shminfolwork);
+            sync_point.arrive_and_wait();
             if (currentDevice == 0)
             {
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyMatrixDesc(descrA));
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyMatrixDesc(descrB));
-
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyGrid(gridA));
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyGrid(gridB));
-
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroy(cusolverH));
-
-                sharedMemoryCleanup(&shminfoA, "shmA");
-                sharedMemoryCleanup(&shminfoB, "shmB");
-                sharedMemoryCleanup(&shminfowork, "shmwork");
-                sharedMemoryCleanup(&shmcsh, "shmcsh");
-                sharedMemoryCleanup(&shminfolwork, "shmlwork");
+                // Unlink file descriptors
+                sharedMemoryUnlink("jaxmg_shmA");
+                sharedMemoryUnlink("jaxmg_shmB");
+                sharedMemoryUnlink("jaxmg_shmwork");
+                sharedMemoryUnlink("jaxmg_shmcsh");
+                sharedMemoryUnlink("jaxmg_shmlwork");
             }
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();

--- a/src/cuda/potrs_mp.cu
+++ b/src/cuda/potrs_mp.cu
@@ -103,8 +103,8 @@ namespace jax
         ffi::Error PotrsMgImpl(int64_t N, int64_t NRHS, int64_t batch_a,
                                gpuStream_t stream, ffi::ScratchAllocator &scratch,
                                ffi::AnyBuffer a, ffi::AnyBuffer b, int64_t tile_size,
-                               ffi::Result<ffi::AnyBuffer> out_a, 
-                               ffi::Result<ffi::AnyBuffer> out_b, 
+                               ffi::Result<ffi::AnyBuffer> out_a,
+                               ffi::Result<ffi::AnyBuffer> out_b,
                                ffi::Result<ffi::Buffer<ffi::S32>> status)
         {
             /* misc */
@@ -168,47 +168,47 @@ namespace jax
             sync_point.arrive_and_wait();
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
 
-            sharedMemoryInfo shminfoAipc;           // Shared memory info for device pointers to local matrices
-            sharedMemoryInfo shminfo_offsetA;       // Shared memory info for offsets of A pointers
-            sharedMemoryInfo shminfoBipc;           // Shared memory info for device pointers to b matrices
-            sharedMemoryInfo shminfo_offsetB;       // Shared memory info for offsets of b pointers
+            sharedMemoryInfo shminfoAipc;            // Shared memory info for device pointers to local matrices
+            sharedMemoryInfo shminfo_offsetA;        // Shared memory info for offsets of A pointers
+            sharedMemoryInfo shminfoBipc;            // Shared memory info for device pointers to b matrices
+            sharedMemoryInfo shminfo_offsetB;        // Shared memory info for offsets of b pointers
             sharedMemoryInfo shminfooutdataaipc;     // Shared memory info for device pointers to out_a matrices
             sharedMemoryInfo shminfooutdatabipc;     // Shared memory info for device pointers to out_b matrices
             sharedMemoryInfo shminfo_offsetoutdataa; // Shared memory info for offsets of out_a pointers
             sharedMemoryInfo shminfo_offsetoutdatab; // Shared memory info for offsets of out_b pointers
-            sharedMemoryInfo shminfoworkipc;        // Shared memory info for workspace pointers
-            sharedMemoryInfo shminfo_offsetwork;    // Shared memory info for offsets of workspace pointers
-            sharedMemoryInfo shminfolwork;          // Shared memory info for lwork
-            sharedMemoryInfo shminfo_csh;           // Shared memory info for cusolver status
+            sharedMemoryInfo shminfoworkipc;         // Shared memory info for workspace pointers
+            sharedMemoryInfo shminfo_offsetwork;     // Shared memory info for offsets of workspace pointers
+            sharedMemoryInfo shminfolwork;           // Shared memory info for lwork
+            sharedMemoryInfo shminfo_csh;            // Shared memory info for cusolver status
 
             // Data handles A
             std::vector<data_type *> shmA(nbGpus, nullptr);
             IpcOpenResult<data_type> opened_ptrs_A;
-            cudaIpcMemHandle_t *shmAipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoAipc, "shmAipc");
-            uintptr_t *shmoffsetA = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetA, "shmoffsetA");
+            cudaIpcMemHandle_t *shmAipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoAipc, "jaxmg_shmAipc");
+            uintptr_t *shmoffsetA = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetA, "jaxmg_shmoffsetA");
             // Data handles b
             std::vector<data_type *> shmB(nbGpus, nullptr);
             IpcOpenResult<data_type> opened_ptrs_B;
-            cudaIpcMemHandle_t *shmBipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoBipc, "shmBipc");
-            uintptr_t *shmoffsetB = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetB, "shmoffsetB");
+            cudaIpcMemHandle_t *shmBipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoBipc, "jaxmg_shmBipc");
+            uintptr_t *shmoffsetB = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetB, "jaxmg_shmoffsetB");
             // Data handles out_data_a
             std::vector<data_type *> shmoutdataa(nbGpus, nullptr);
             IpcOpenResult<data_type> opened_ptrs_outdataa;
-            cudaIpcMemHandle_t *shmoutdataaipc = get_shm_ipc_handles(currentDevice, sync_point, shminfooutdataaipc, "shmoutdataaipc");
-            uintptr_t *shmoffsetoutdataa = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetoutdataa, "shmoffsetoutdataa");
+            cudaIpcMemHandle_t *shmoutdataaipc = get_shm_ipc_handles(currentDevice, sync_point, shminfooutdataaipc, "jaxmg_shmoutdataaipc");
+            uintptr_t *shmoffsetoutdataa = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetoutdataa, "jaxmg_shmoffsetoutdataa");
             // Data handles out_data_b
             std::vector<data_type *> shmoutdatab(nbGpus, nullptr);
             IpcOpenResult<data_type> opened_ptrs_outdatab;
-            cudaIpcMemHandle_t *shmoutdatabipc = get_shm_ipc_handles(currentDevice, sync_point, shminfooutdatabipc, "shmoutdatabipc");
-            uintptr_t *shmoffsetoutdatab = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetoutdatab, "shmoffsetoutdatab");
+            cudaIpcMemHandle_t *shmoutdatabipc = get_shm_ipc_handles(currentDevice, sync_point, shminfooutdatabipc, "jaxmg_shmoutdatabipc");
+            uintptr_t *shmoffsetoutdatab = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetoutdatab, "jaxmg_shmoffsetoutdatab");
             // Data handles shmwork
             std::vector<data_type *> shmwork(nbGpus, nullptr);
             IpcOpenResult<data_type> opened_ptrs_work;
-            cudaIpcMemHandle_t *shmworkipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoworkipc, "shmworkipc");
-            uintptr_t *shmoffsetwork = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetwork, "shmoffsetwork");
+            cudaIpcMemHandle_t *shmworkipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoworkipc, "jaxmg_shmworkipc");
+            uintptr_t *shmoffsetwork = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetwork, "jaxmg_shmoffsetwork");
 
-            int32_t *cusolver_status_host = get_shm_lwork_ptr<int32_t>(currentDevice, sync_point, shminfo_csh, "shmcsh");
-            int64_t *shmlwork = get_shm_lwork_ptr<int64_t>(currentDevice, sync_point, shminfolwork, "shmlwork");
+            int32_t *cusolver_status_host = get_shm_lwork_ptr<int32_t>(currentDevice, sync_point, shminfo_csh, "jaxmg_shmcsh");
+            int64_t *shmlwork = get_shm_lwork_ptr<int64_t>(currentDevice, sync_point, shminfolwork, "jaxmg_shmlwork");
 
             if (currentDevice == 0)
             {
@@ -396,7 +396,8 @@ namespace jax
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
             // Set output pointers for A
-            if (cusolver_status_host[currentDevice] == 0){
+            if (cusolver_status_host[currentDevice] == 0)
+            {
                 shmoutdataa[currentDevice] = shmA[currentDevice];
             }
             // Fill nans if solver failed
@@ -407,6 +408,20 @@ namespace jax
             }
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
+            // Close file descriptors
+            sharedMemoryClose(&shminfo_offsetA);
+            sharedMemoryClose(&shminfoAipc);
+            sharedMemoryClose(&shminfo_offsetB);
+            sharedMemoryClose(&shminfoBipc);
+            sharedMemoryClose(&shminfo_offsetoutdataa);
+            sharedMemoryClose(&shminfo_offsetoutdatab);
+            sharedMemoryClose(&shminfooutdataaipc);
+            sharedMemoryClose(&shminfooutdatabipc);
+            sharedMemoryClose(&shminfoworkipc);
+            sharedMemoryClose(&shminfo_offsetwork);
+            sharedMemoryClose(&shminfolwork);
+            sharedMemoryClose(&shminfo_csh);
+            sync_point.arrive_and_wait();
             if (currentDevice == 0)
             {
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyMatrixDesc(descrA));
@@ -416,19 +431,19 @@ namespace jax
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyGrid(gridB));
 
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroy(cusolverH));
-                // Shared memory close
-                sharedMemoryCleanup(&shminfo_offsetA, "shmoffsetA");
-                sharedMemoryCleanup(&shminfoAipc, "shmAipc");
-                sharedMemoryCleanup(&shminfo_offsetB, "shmoffsetB");
-                sharedMemoryCleanup(&shminfoBipc, "shmBipc");
-                sharedMemoryCleanup(&shminfo_offsetoutdataa, "shmoffsetoutdataa");
-                sharedMemoryCleanup(&shminfo_offsetoutdatab, "shmoffsetoutdatab");
-                sharedMemoryCleanup(&shminfooutdatabipc, "shmoutdataaipc");
-                sharedMemoryCleanup(&shminfooutdatabipc, "shmoutdatabipc");
-                sharedMemoryCleanup(&shminfoworkipc, "shmworkipc");
-                sharedMemoryCleanup(&shminfo_offsetwork, "shmoffsetwork");
-                sharedMemoryCleanup(&shminfolwork, "shmlwork");
-                sharedMemoryCleanup(&shminfo_csh, "shmcsh");
+                // Shared memory unlink
+                sharedMemoryUnlink("jaxmg_shmoffsetA");
+                sharedMemoryUnlink("jaxmg_shmAipc");
+                sharedMemoryUnlink("jaxmg_shmoffsetB");
+                sharedMemoryUnlink("jaxmg_shmBipc");
+                sharedMemoryUnlink("jaxmg_shmoffsetoutdataa");
+                sharedMemoryUnlink("jaxmg_shmoffsetoutdatab");
+                sharedMemoryUnlink("jaxmg_shmoutdataaipc");
+                sharedMemoryUnlink("jaxmg_shmoutdatabipc");
+                sharedMemoryUnlink("jaxmg_shmworkipc");
+                sharedMemoryUnlink("jaxmg_shmoffsetwork");
+                sharedMemoryUnlink("jaxmg_shmlwork");
+                sharedMemoryUnlink("jaxmg_shmcsh");
                 // Close memory handles
                 ipcCloseDevicePointers(currentDevice, opened_ptrs_A.bases, nbGpus);
                 ipcCloseDevicePointers(currentDevice, opened_ptrs_B.bases, nbGpus);
@@ -438,7 +453,7 @@ namespace jax
             }
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.close_and_wait();
-            
+
             return ffi::Error::Success();
         }
 
@@ -446,7 +461,7 @@ namespace jax
                                    ffi::AnyBuffer a, ffi::AnyBuffer b, int64_t tile_size,
                                    ffi::Result<ffi::AnyBuffer> out_a,
                                    ffi::Result<ffi::AnyBuffer> out_b,
-                                    ffi::Result<ffi::Buffer<ffi::S32>> status)
+                                   ffi::Result<ffi::Buffer<ffi::S32>> status)
         {
             auto dataType = a.element_type();
 
@@ -472,7 +487,7 @@ namespace jax
             }
             FFI_RETURN_IF_ERROR(CheckShape(status->dimensions(), 1, "status", "potrf"));
 
-            SOLVER_DISPATCH_IMPL(PotrsMgImpl, N, NRHS, batch_a, stream, scratch, a, b, tile_size, out_a,out_b, status);
+            SOLVER_DISPATCH_IMPL(PotrsMgImpl, N, NRHS, batch_a, stream, scratch, a, b, tile_size, out_a, out_b, status);
 
             return ffi::Error::InvalidArgument(absl::StrFormat(
                 "Unsupported data type%s for potrs", absl::FormatStreamed(dataType)));

--- a/src/cuda/syevd.cu
+++ b/src/cuda/syevd.cu
@@ -159,12 +159,12 @@ namespace jax
             sharedMemoryInfo shminfolwork; // Shared memory info for lwork space nbytes
             sharedMemoryInfo shmcsh;       // Shared memory info for cusolver status
 
-            data_type **shmA = get_shm_device_ptrs<data_type>(currentDevice, sync_point, shminfoA, "shmA");    // Actual shared memory
-            eigenvalue_type **shmev = get_shm_device_ptrs<eigenvalue_type>(currentDevice, sync_point, shminfoev, "shmev"); // Actual shared memory
-            data_type **shmwork = get_shm_device_ptrs<data_type>(currentDevice, sync_point, shminfowork, "shmwork");
+            data_type **shmA = get_shm_device_ptrs<data_type>(currentDevice, sync_point, shminfoA, "jaxmg_shmA");    // Actual shared memory
+            eigenvalue_type **shmev = get_shm_device_ptrs<eigenvalue_type>(currentDevice, sync_point, shminfoev, "jaxmg_shmev"); // Actual shared memory
+            data_type **shmwork = get_shm_device_ptrs<data_type>(currentDevice, sync_point, shminfowork, "jaxmg_shmwork");
 
-            int32_t *cusolver_status_host = get_shm_lwork_ptr<int32_t, ThreadBarrier>(currentDevice, sync_point, shmcsh, "shmcsh");
-            int64_t *shmlwork = get_shm_lwork_ptr<int64_t, ThreadBarrier>(currentDevice, sync_point, shminfolwork, "shmlwork");
+            int32_t *cusolver_status_host = get_shm_lwork_ptr<int32_t, ThreadBarrier>(currentDevice, sync_point, shmcsh, "jaxmg_shmcsh");
+            int64_t *shmlwork = get_shm_lwork_ptr<int64_t, ThreadBarrier>(currentDevice, sync_point, shminfolwork, "jaxmg_shmlwork");
 
             if (currentDevice == 0)
             {
@@ -297,20 +297,24 @@ namespace jax
             }
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
-
+            // Close file descriptors
+            sharedMemoryClose(&shminfoA);
+            sharedMemoryClose(&shminfoev);
+            sharedMemoryClose(&shminfowork);
+            sharedMemoryClose(&shmcsh);
+            sharedMemoryClose(&shminfolwork);
+            sync_point.arrive_and_wait();
             if (currentDevice == 0)
             {
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyMatrixDesc(descrA));
-
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyGrid(gridA));
-
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroy(cusolverH));
-
-                sharedMemoryCleanup(&shminfoA, "shmA");
-                sharedMemoryCleanup(&shminfoev, "shmev");
-                sharedMemoryCleanup(&shminfowork, "shmwork");
-                sharedMemoryCleanup(&shmcsh, "shmcsh");
-                sharedMemoryCleanup(&shminfolwork, "shmlwork");
+                // Unlink file descriptors
+                sharedMemoryUnlink("jaxmg_shmA");
+                sharedMemoryUnlink("jaxmg_shmev");
+                sharedMemoryUnlink("jaxmg_shmwork");
+                sharedMemoryUnlink("jaxmg_shmcsh");
+                sharedMemoryUnlink("jaxmg_shmlwork");
             }
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();

--- a/src/cuda/syevd_mp.cu
+++ b/src/cuda/syevd_mp.cu
@@ -111,8 +111,8 @@ namespace jax
             /* misc */
             const std::string &source = __FILE__;
             /* data types*/
-            cudaDataType compute_type_cu = traits<data_type>::cuda_data_type; // Data type for computation
-            using eigenvalue_type = typename traits<data_type>::S;          // Get the C++ real type
+            cudaDataType compute_type_cu = traits<data_type>::cuda_data_type;          // Data type for computation
+            using eigenvalue_type = typename traits<data_type>::S;                     // Get the C++ real type
             cudaDataType eigenvalue_type_cu = traits<eigenvalue_type>::cuda_data_type; // Get the CUDA real type
             /* GPU */
             const int MAX_NUM_DEVICES = 16;
@@ -170,29 +170,29 @@ namespace jax
             // Data handles A
             std::vector<data_type *> shmA(nbGpus, nullptr);
             IpcOpenResult<data_type> opened_ptrs_A;
-            cudaIpcMemHandle_t *shmAipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoAipc, "shmAipc");
-            uintptr_t *shmoffsetA = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetA, "shmoffsetA");
+            cudaIpcMemHandle_t *shmAipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoAipc, "jaxmg_shmAipc");
+            uintptr_t *shmoffsetA = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetA, "jaxmg_shmoffsetA");
 
             // Data handles eigenvalues
             std::vector<eigenvalue_type *> shmev(nbGpus, nullptr);
             IpcOpenResult<eigenvalue_type> opened_ptrs_ev;
-            cudaIpcMemHandle_t *shmevipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoevipc, "shmevipc");
-            uintptr_t *shmoffsetev = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetev, "shmoffsetev");
+            cudaIpcMemHandle_t *shmevipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoevipc, "jaxmg_shmevipc");
+            uintptr_t *shmoffsetev = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetev, "jaxmg_shmoffsetev");
 
             // Data handles V (eigenvectors)
             std::vector<data_type *> shmV(nbGpus, nullptr);
             IpcOpenResult<data_type> opened_ptrs_V;
-            cudaIpcMemHandle_t *shmVipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoVipc, "shmVipc");
-            uintptr_t *shmoffsetV = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetV, "shmoffsetV");
+            cudaIpcMemHandle_t *shmVipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoVipc, "jaxmg_shmVipc");
+            uintptr_t *shmoffsetV = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetV, "jaxmg_shmoffsetV");
 
             // Workspace
             std::vector<data_type *> shmwork(nbGpus, nullptr);
             IpcOpenResult<data_type> opened_ptrs_work;
-            cudaIpcMemHandle_t *shmworkipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoworkipc, "shmworkipc");
-            uintptr_t *shmoffsetwork = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetwork, "shmoffsetwork");
+            cudaIpcMemHandle_t *shmworkipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoworkipc, "jaxmg_shmworkipc");
+            uintptr_t *shmoffsetwork = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetwork, "jaxmg_shmoffsetwork");
 
-            int32_t *cusolver_status_host = get_shm_lwork_ptr<int32_t>(currentDevice, sync_point, shminfo_csh, "shmcsh");
-            int64_t *shmlwork = get_shm_lwork_ptr<int64_t>(currentDevice, sync_point, shminfolwork, "shmlwork");
+            int32_t *cusolver_status_host = get_shm_lwork_ptr<int32_t>(currentDevice, sync_point, shminfo_csh, "jaxmg_shmcsh");
+            int64_t *shmlwork = get_shm_lwork_ptr<int64_t>(currentDevice, sync_point, shminfolwork, "jaxmg_shmlwork");
 
             if (currentDevice == 0)
             {
@@ -348,7 +348,7 @@ namespace jax
                     // Set out pointers inplace
                     for (int dev = 0; dev < nbGpus; dev++)
                     {
-                        shmV[dev]= shmA[dev];
+                        shmV[dev] = shmA[dev];
                     }
                 }
             }
@@ -361,23 +361,37 @@ namespace jax
             }
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
+            // Close file descriptors
+            sharedMemoryClose(&shminfo_offsetA);
+            sharedMemoryClose(&shminfoAipc);
+            sharedMemoryClose(&shminfo_offsetev);
+            sharedMemoryClose(&shminfoevipc);
+            sharedMemoryClose(&shminfo_offsetV);
+            sharedMemoryClose(&shminfoVipc);
+            sharedMemoryClose(&shminfoworkipc);
+            sharedMemoryClose(&shminfo_offsetwork);
+            sharedMemoryClose(&shminfolwork);
+            sharedMemoryClose(&shminfo_csh);
 
+            sync_point.arrive_and_wait();
             if (currentDevice == 0)
             {
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyMatrixDesc(descrA));
-                CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyGrid(gridA));
-                CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroy(cusolverH));
 
-                sharedMemoryCleanup(&shminfo_offsetA, "shmoffsetA");
-                sharedMemoryCleanup(&shminfoAipc, "shmAipc");
-                sharedMemoryCleanup(&shminfo_offsetev, "shmoffsetev");
-                sharedMemoryCleanup(&shminfoevipc, "shmevipc");
-                sharedMemoryCleanup(&shminfo_offsetV, "shmoffsetV");
-                sharedMemoryCleanup(&shminfoVipc, "shmVipc");
-                sharedMemoryCleanup(&shminfoworkipc, "shmworkipc");
-                sharedMemoryCleanup(&shminfo_offsetwork, "shmoffsetwork");
-                sharedMemoryCleanup(&shminfolwork, "shmlwork");
-                sharedMemoryCleanup(&shminfo_csh, "shmcsh");
+                CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyGrid(gridA));
+
+                CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroy(cusolverH));
+                // Shared memory unlink
+                sharedMemoryUnlink("jaxmg_shmoffsetA");
+                sharedMemoryUnlink("jaxmg_shmAipc");
+                sharedMemoryUnlink("jaxmg_shmoffsetev");
+                sharedMemoryUnlink("jaxmg_shmevipc");
+                sharedMemoryUnlink("jaxmg_shmoffsetV");
+                sharedMemoryUnlink("jaxmg_shmVipc");
+                sharedMemoryUnlink("jaxmg_shmworkipc");
+                sharedMemoryUnlink("jaxmg_shmoffsetwork");
+                sharedMemoryUnlink("jaxmg_shmlwork");
+                sharedMemoryUnlink("jaxmg_shmcsh");
 
                 ipcCloseDevicePointers(currentDevice, opened_ptrs_A.bases, nbGpus);
                 ipcCloseDevicePointers(currentDevice, opened_ptrs_ev.bases, nbGpus);

--- a/src/cuda/syevd_no_V.cu
+++ b/src/cuda/syevd_no_V.cu
@@ -156,12 +156,12 @@ namespace jax
             sharedMemoryInfo shminfolwork; // Shared memory info for lwork space nbytes
             sharedMemoryInfo shmcsh;       // Shared memory info for cusolver status
 
-            data_type **shmA = get_shm_device_ptrs<data_type>(currentDevice, sync_point, shminfoA, "shmA");          // Actual shared memory
-            eigenvalue_type **shmev = get_shm_device_ptrs<eigenvalue_type>(currentDevice, sync_point, shminfoev, "shmev"); // Actual shared memory
-            data_type **shmwork = get_shm_device_ptrs<data_type>(currentDevice, sync_point, shminfowork, "shmwork");
+            data_type **shmA = get_shm_device_ptrs<data_type>(currentDevice, sync_point, shminfoA, "jaxmg_shmA");                // Actual shared memory
+            eigenvalue_type **shmev = get_shm_device_ptrs<eigenvalue_type>(currentDevice, sync_point, shminfoev, "jaxmg_shmev"); // Actual shared memory
+            data_type **shmwork = get_shm_device_ptrs<data_type>(currentDevice, sync_point, shminfowork, "jaxmg_shmwork");
 
-            int32_t *cusolver_status_host = get_shm_lwork_ptr<int32_t, ThreadBarrier>(currentDevice, sync_point, shmcsh, "shmcsh");
-            int64_t *shmlwork = get_shm_lwork_ptr<int64_t, ThreadBarrier>(currentDevice, sync_point, shminfolwork, "shmlwork");
+            int32_t *cusolver_status_host = get_shm_lwork_ptr<int32_t, ThreadBarrier>(currentDevice, sync_point, shmcsh, "jaxmg_shmcsh");
+            int64_t *shmlwork = get_shm_lwork_ptr<int64_t, ThreadBarrier>(currentDevice, sync_point, shminfolwork, "jaxmg_shmlwork");
 
             if (currentDevice == 0)
             {
@@ -283,17 +283,24 @@ namespace jax
             }
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();
+            // Close file descriptors
+            sharedMemoryClose(&shminfoA);
+            sharedMemoryClose(&shminfoev);
+            sharedMemoryClose(&shminfowork);
+            sharedMemoryClose(&shmcsh);
+            sharedMemoryClose(&shminfolwork);
+            sync_point.arrive_and_wait();
             if (currentDevice == 0)
             {
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyMatrixDesc(descrA));
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyGrid(gridA));
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroy(cusolverH));
-
-                sharedMemoryCleanup(&shminfoA, "shmA");
-                sharedMemoryCleanup(&shminfoev, "shmev");
-                sharedMemoryCleanup(&shminfowork, "shmwork");
-                sharedMemoryCleanup(&shmcsh, "shmcsh");
-                sharedMemoryCleanup(&shminfolwork, "shmlwork");
+                // Unlink file descriptors
+                sharedMemoryUnlink("jaxmg_shmA");
+                sharedMemoryUnlink("jaxmg_shmev");
+                sharedMemoryUnlink("jaxmg_shmwork");
+                sharedMemoryUnlink("jaxmg_shmcsh");
+                sharedMemoryUnlink("jaxmg_shmlwork");
             }
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
             sync_point.arrive_and_wait();

--- a/src/cuda/syevd_no_V_mp.cu
+++ b/src/cuda/syevd_no_V_mp.cu
@@ -166,23 +166,23 @@ namespace jax
             // Data handles A
             std::vector<data_type *> shmA(nbGpus, nullptr);
             IpcOpenResult<data_type> opened_ptrs_A;
-            cudaIpcMemHandle_t *shmAipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoAipc, "shmAipc");
-            uintptr_t *shmoffsetA = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetA, "shmoffsetA");
+            cudaIpcMemHandle_t *shmAipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoAipc, "jaxmg_shmAipc");
+            uintptr_t *shmoffsetA = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetA, "jaxmg_shmoffsetA");
 
             // Data handles eigenvalues
             std::vector<eigenvalue_type *> shmev(nbGpus, nullptr);
             IpcOpenResult<eigenvalue_type> opened_ptrs_ev;
-            cudaIpcMemHandle_t *shmevipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoevipc, "shmevipc");
-            uintptr_t *shmoffsetev = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetev, "shmoffsetev");
+            cudaIpcMemHandle_t *shmevipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoevipc, "jaxmg_shmevipc");
+            uintptr_t *shmoffsetev = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetev, "jaxmg_shmoffsetev");
 
             // Workspace
             std::vector<data_type *> shmwork(nbGpus, nullptr);
             IpcOpenResult<data_type> opened_ptrs_work;
-            cudaIpcMemHandle_t *shmworkipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoworkipc, "shmworkipc");
-            uintptr_t *shmoffsetwork = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetwork, "shmoffsetwork");
+            cudaIpcMemHandle_t *shmworkipc = get_shm_ipc_handles(currentDevice, sync_point, shminfoworkipc, "jaxmg_shmworkipc");
+            uintptr_t *shmoffsetwork = get_shm_lwork_ptr<uintptr_t>(currentDevice, sync_point, shminfo_offsetwork, "jaxmg_shmoffsetwork");
 
-            int32_t *cusolver_status_host = get_shm_lwork_ptr<int32_t>(currentDevice, sync_point, shminfo_csh, "shmcsh");
-            int64_t *shmlwork = get_shm_lwork_ptr<int64_t>(currentDevice, sync_point, shminfolwork, "shmlwork");
+            int32_t *cusolver_status_host = get_shm_lwork_ptr<int32_t>(currentDevice, sync_point, shminfo_csh, "jaxmg_shmcsh");
+            int64_t *shmlwork = get_shm_lwork_ptr<int64_t>(currentDevice, sync_point, shminfolwork, "jaxmg_shmlwork");
 
             if (currentDevice == 0)
             {
@@ -328,21 +328,30 @@ namespace jax
                 JAX_FFI_RETURN_IF_GPU_ERROR(gpuMemcpy(array_data_eigenvalues, host_ev_nan.data(), sizeof(data_type) * N, gpuMemcpyHostToDevice));
             }
             CUDA_CHECK_OR_RETURN(cudaDeviceSynchronize());
+            // Close file descriptors
+            sharedMemoryClose(&shminfo_offsetA);
+            sharedMemoryClose(&shminfoAipc);
+            sharedMemoryClose(&shminfo_offsetev);
+            sharedMemoryClose(&shminfoevipc);
+            sharedMemoryClose(&shminfoworkipc);
+            sharedMemoryClose(&shminfo_offsetwork);
+            sharedMemoryClose(&shminfolwork);
+            sharedMemoryClose(&shminfo_csh);
             sync_point.arrive_and_wait();
             if (currentDevice == 0)
             {
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyMatrixDesc(descrA));
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroyGrid(gridA));
                 CUSOLVER_CHECK_OR_RETURN(cusolverMgDestroy(cusolverH));
-
-                sharedMemoryCleanup(&shminfo_offsetA, "shmoffsetA");
-                sharedMemoryCleanup(&shminfoAipc, "shmAipc");
-                sharedMemoryCleanup(&shminfo_offsetev, "shmoffsetev");
-                sharedMemoryCleanup(&shminfoevipc, "shmevipc");
-                sharedMemoryCleanup(&shminfoworkipc, "shmworkipc");
-                sharedMemoryCleanup(&shminfo_offsetwork, "shmoffsetwork");
-                sharedMemoryCleanup(&shminfolwork, "shmlwork");
-                sharedMemoryCleanup(&shminfo_csh, "shmcsh");
+                // Shared memory unlink
+                sharedMemoryUnlink("jaxmg_shmoffsetA");
+                sharedMemoryUnlink("jaxmg_shmAipc");
+                sharedMemoryUnlink("jaxmg_shmoffsetev");
+                sharedMemoryUnlink("jaxmg_shmevipc");
+                sharedMemoryUnlink("jaxmg_shmworkipc");
+                sharedMemoryUnlink("jaxmg_shmoffsetwork");
+                sharedMemoryUnlink("jaxmg_shmlwork");
+                sharedMemoryUnlink("jaxmg_shmcsh");
 
                 ipcCloseDevicePointers(currentDevice, opened_ptrs_A.bases, nbGpus);
                 ipcCloseDevicePointers(currentDevice, opened_ptrs_ev.bases, nbGpus);

--- a/src/cuda/utils/shm.cc
+++ b/src/cuda/utils/shm.cc
@@ -136,31 +136,20 @@ void sharedMemoryUnlink(const char *name)
   }
 }
 
-void sharedMemoryCleanup(sharedMemoryInfo *info, const char *name)
-{
-  std::string lshmName = std::string("/jaxmg_") + name;
-  /* Close any mapping / fd owned in info. */
-  sharedMemoryClose(info);
-
-  /* Unlink the named shm (sharedMemoryUnlink returns 0 on success or errno). */
-  sharedMemoryUnlink(lshmName.c_str());
-}
-
 template <typename T>
 T **get_shm_device_ptrs(int currentDevice, ThreadBarrier &sync_point, sharedMemoryInfo &info, const char *shmName)
 {
   T **shm = nullptr;
   pid_t pid = getppid();
   const int MAX_NUM_DEVICES = 16;
-  std::string lshmName = std::string("/jaxmg_") + shmName;
 
   size_t shmSize = MAX_NUM_DEVICES * sizeof(T *);
 
   if (currentDevice == 0)
   {
-    if (sharedMemoryCreate(lshmName.c_str(), shmSize, &info) != 0)
+    if (sharedMemoryCreate(shmName, shmSize, &info) != 0)
     {
-      printf("Failed to create shared memory '%s'\n", lshmName.c_str());
+      printf("Failed to create shared memory '%s'\n", shmName);
       exit(EXIT_FAILURE); // #TODO: replace this with proper JAX error handling
     }
     shm = (T **)info.addr;
@@ -171,7 +160,7 @@ T **get_shm_device_ptrs(int currentDevice, ThreadBarrier &sync_point, sharedMemo
 
   if (currentDevice != 0)
   {
-    if (sharedMemoryOpen(lshmName.c_str(), shmSize, &info) != 0)
+    if (sharedMemoryOpen(shmName, shmSize, &info) != 0)
     {
       printf("Failed to open shared memory in dev %d\n", currentDevice);
       exit(EXIT_FAILURE);
@@ -194,13 +183,12 @@ T *get_shm_lwork_ptr(int currentDevice, barrier &sync_point, sharedMemoryInfo &i
 {
   pid_t pid = getppid();
   const int MAX_NUM_DEVICES = 16;
-  std::string lshmName = std::string("/jaxmg_") + shmName;
 
   size_t shmSize = MAX_NUM_DEVICES * sizeof(T);
   T *shm = nullptr;
   if (currentDevice == 0)
   {
-    if (sharedMemoryCreate(lshmName.c_str(), shmSize, &info) != 0)
+    if (sharedMemoryCreate(shmName, shmSize, &info) != 0)
     {
       printf("Failed to create shared memory\n");
       exit(EXIT_FAILURE); // #TODO: Replace this with proper JAX error handling
@@ -214,9 +202,9 @@ T *get_shm_lwork_ptr(int currentDevice, barrier &sync_point, sharedMemoryInfo &i
 
   if (currentDevice != 0)
   {
-    if (sharedMemoryOpen(lshmName.c_str(), shmSize, &info) != 0)
+    if (sharedMemoryOpen(shmName, shmSize, &info) != 0)
     {
-      printf("Failed to open shared memory '%s'\n", lshmName.c_str());
+      printf("Failed to open shared memory '%s'\n", shmName);
       exit(EXIT_FAILURE);
     }
     shm = reinterpret_cast<T *>(info.addr);
@@ -240,12 +228,11 @@ cudaIpcMemHandle_t *get_shm_ipc_handles(int currentDevice, DynamicBarrier &sync_
   const int MAX_NUM_DEVICES = 16;
 
   // Use a stable, shared name (not PID)
-  std::string name = std::string("/jaxmg") + shmName;       // e.g., "/shmA" – include your session suffix if you have one
   size_t sz = sizeof(cudaIpcMemHandle_t) * MAX_NUM_DEVICES; // nbGpus must be visible here
 
   if (currentDevice == 0)
   {
-    int rc = sharedMemoryCreate(name.c_str(), sz, &info);
+    int rc = sharedMemoryCreate(shmName, sz, &info);
     if (rc)
     {
 
@@ -259,7 +246,7 @@ cudaIpcMemHandle_t *get_shm_ipc_handles(int currentDevice, DynamicBarrier &sync_
 
   if (currentDevice != 0)
   {
-    int rc = sharedMemoryOpen(name.c_str(), sz, &info);
+    int rc = sharedMemoryOpen(shmName, sz, &info);
     if (rc)
     {
       printf("Failed to open shared memory IPC\n");

--- a/src/cuda/utils/shm.h
+++ b/src/cuda/utils/shm.h
@@ -31,8 +31,6 @@ void sharedMemoryClose(sharedMemoryInfo *info);
 
 void sharedMemoryUnlink(const char *name);
 
-void sharedMemoryCleanup(sharedMemoryInfo *info, const char *name);
-
 template <typename T>
 T **get_shm_device_ptrs(int currentDevice, ThreadBarrier &sync_point, sharedMemoryInfo &info, const char *shmName);
 

--- a/src/jaxmg/_potri.py
+++ b/src/jaxmg/_potri.py
@@ -1,13 +1,12 @@
 import os
-import ctypes
+
 import jax
 import jax.numpy as jnp
-
 from jax import Array
 from jax.sharding import PartitionSpec as P, Mesh
 
 from functools import partial
-from typing import Tuple, Union
+from typing import Tuple, Union, List
 
 from ._cyclic_1d import calculate_padding, pad_rows, unpad_rows
 
@@ -16,7 +15,7 @@ def potri(
     a: Array,
     T_A: int,
     mesh: Mesh,
-    in_specs: Tuple[P] | P,
+    in_specs: Tuple[P] | List[P] | P,
     return_status: bool = False,
     pad=True,
 ) -> Union[Array, Tuple[Array, int]]:
@@ -45,7 +44,8 @@ def potri(
             ``T_A`` that is incompatible with the shard size we pad the matrix
             accordingly. For small tile sizes (``T_A``< 128), the solver can 
             be extremely slow, so ensure that ``T_A`` is large enough. In principle,
-            the larger ``T_A`` the faster the solver runs.
+            the larger ``T_A`` the faster the solver runs. See https://arxiv.org/abs/2601.14466
+            for more details.
         mesh (Mesh): JAX device mesh used for ``jax.shard_map``.
         in_specs (PartitionSpec or tuple/list[PartitionSpec]): PartitionSpec
             describing the input sharding (row sharding). May be provided as a

--- a/src/jaxmg/_potrs.py
+++ b/src/jaxmg/_potrs.py
@@ -1,6 +1,6 @@
 import os
-import jax
 
+import jax
 import jax.numpy as jnp
 from jax import Array
 from jax.sharding import PartitionSpec as P, Mesh

--- a/src/jaxmg/_potrs.py
+++ b/src/jaxmg/_potrs.py
@@ -1,5 +1,4 @@
 import os
-import ctypes
 import jax
 
 import jax.numpy as jnp
@@ -17,7 +16,7 @@ def potrs(
     b: Array,
     T_A: int,
     mesh: Mesh,
-    in_specs: Tuple[P, P] | List[P],
+    in_specs: Tuple[P] | List[P] | P,
     return_status: bool = False,
     pad=True,
 ) -> Union[Array, Tuple[Array, int]]:
@@ -42,16 +41,18 @@ def potrs(
             Expected to be sharded across the mesh along the first (row) axis
             using a single ``PartitionSpec``: ``P(<axis_name>, None)``.
         b (Array): 2D right-hand side. Expected to be replicated across
-            devices with ``PartitionSpec`` ``P(None, None)``.
+            devices with ``PartitionSpec`` ``P(None, None)`` or ``P(None)``.
         T_A (int): Tile width used by the native solver. Each
             local shard length must be a multiple of ``T_A``. If the user provides a
             ``T_A`` that is incompatible with the shard size we pad the matrix
             accordingly. For small tile sizes (``T_A``< 128), the solver can
             be extremely slow, so ensure that ``T_A`` is large enough. In principle,
-            the larger ``T_A`` the faster the solver runs.
+            the larger ``T_A`` the faster the solver runs. See https://arxiv.org/abs/2601.14466
+            for more details.
         mesh (Mesh): JAX Mesh object used for ``jax.shard_map``.
-        in_specs (tuple[list][PartitionSpec]): The sharding specifications for
-            ``(a, b)``. Expected to be ``(P(<axis_name>, None), P(None, None))``.
+        in_specs (PartitionSpec or tuple/list[PartitionSpec]): PartitionSpec
+            describing the input sharding (row sharding). May be provided as a
+            single ``PartitionSpec`` or a single-element container containing one.
         return_status (bool, optional): If True return ``(x, status)`` where
             ``status`` is a host-replicated int32 from the native solver. If
             False return ``x`` only. Default is False.
@@ -65,12 +66,11 @@ def potrs(
             If ``return_status=True`` also return the native solver status.
 
     Raises:
-        AssertionError: If ``a`` or ``b`` are not 2D, or their shapes are
-            incompatible.
-        ValueError: If ``in_specs`` is not a 2-element sequence or if the
+        AssertionError: If ``a`` or ``b`` are not the correct shape, or if 
+        their shapes are incompatible.
+        ValueError: If ``in_specs`` is not a 1-element sequence or if the
             provided ``PartitionSpec`` objects do not match the required
-            patterns (``P(<axis_name>, None)`` for ``a`` and
-            ``P(None, None)`` for ``b``).
+            patterns (``P(<axis_name>, None)`` for ``a``.
 
     Notes:
         - The FFI call may donate the ``a`` buffer (``donate_argnums=0``) for
@@ -81,26 +81,30 @@ def potrs(
 
     ndev = int(os.environ["JAXMG_NUMBER_OF_DEVICES"])
 
-    assert isinstance(
-        in_specs, (tuple, list)
-    ), f"expected `in_specs` to be a tuple or list of `PartitionSpec` objects, received {in_specs}"
-    assert len(in_specs) == 2, f"expected two `in_specs`, received {in_specs}"
-
-    spec_a, spec_b = in_specs
-    if (spec_a._partitions[0] == None) or (spec_a._partitions[1] != None):
+    if isinstance(in_specs, (list, tuple)):
+        if len(in_specs) != 1:
+            raise ValueError(
+                "in_specs must be a single PartitionSpec or a 1-element list/tuple."
+            )
+        in_specs = in_specs[0]
+    if not isinstance(in_specs, P):
+        raise TypeError(
+            "in_specs must be a PartitionSpec or a 1-element list/tuple containing one."
+        )
+    if (in_specs._partitions[0] == None) or (in_specs._partitions[1] != None):
         raise ValueError(
             "A must be sharded along the columns with PartitionSpec P(None, str)."
-        )
-    if spec_b != P(None, None):
-        raise ValueError(
-            "b must be replicated along all shards with PartitionSpec P(None, None)."
         )
 
     assert a.shape[1] == b.shape[0], "A and b must have the same number of columns."
     assert a.ndim == 2, "a must be a 2D array."
-    assert b.ndim == 2, "b must be a 2D array."
+    assert b.ndim <= 2, "b must be a 1D or 2D array."
+    # ensure b is always 2D
+    if b.ndim == 1:
+        b = jnp.expand_dims(b, axis=1)
+
     N_rows, N = a.shape
-    axis_name = spec_a._partitions[0]
+    axis_name = in_specs._partitions[0]
 
     shard_size = N_rows // ndev
 

--- a/src/jaxmg/_syevd.py
+++ b/src/jaxmg/_syevd.py
@@ -126,7 +126,7 @@ def syevd(
     assert a.ndim == 2, "a must be a 2D array."
     if T_A > 1024:
         raise ValueError(
-            "T_A has a maximum value of 1024 for SyevdMg, received T_A={T_A}"
+            f"T_A has a maximum value of 1024 for SyevdMg, received T_A={T_A}"
         )
     axis_name = in_specs._partitions[0]
     N_rows, N = a.shape

--- a/src/jaxmg/_syevd.py
+++ b/src/jaxmg/_syevd.py
@@ -18,7 +18,6 @@ and packaging of the extension are useful for testing.
 """
 
 import os
-import ctypes
 
 import jax
 import jax.numpy as jnp
@@ -26,9 +25,11 @@ from jax import Array
 from jax.sharding import PartitionSpec as P, Mesh
 
 from functools import partial
-from typing import Tuple, Union
+from typing import Tuple, Union, List
 
-from .utils import maybe_real_dtype_from_complex
+import warnings
+
+from .utils import maybe_real_dtype_from_complex, JaxMgWarning
 from ._cyclic_1d import calculate_padding, pad_rows, unpad_rows
 
 
@@ -36,7 +37,7 @@ def syevd(
     a: Array,
     T_A: int,
     mesh: Mesh,
-    in_specs: Tuple[P],
+    in_specs: Tuple[P] | List[P] | P,
     return_eigenvectors: bool = True,
     return_status: bool = False,
     pad=True,
@@ -68,7 +69,8 @@ def syevd(
             accordingly. For small tile sizes (``T_A``< 128), the solver can 
             be extremely slow, so ensure that ``T_A`` is large enough. 
             The Cusolver implementation enforces an upper bound of
-            ``T_A <= 1024``.
+            ``T_A <= 1024``. See https://arxiv.org/abs/2601.14466
+            for more details.
         mesh (Mesh): JAX device mesh used for ``jax.shard_map``.
         in_specs (PartitionSpec or tuple/list[PartitionSpec]): PartitionSpec
             describing the input sharding (row sharding). May be provided as a
@@ -125,9 +127,13 @@ def syevd(
         )
     assert a.ndim == 2, "a must be a 2D array."
     if T_A > 1024:
-        raise ValueError(
-            f"T_A has a maximum value of 1024 for SyevdMg, received T_A={T_A}"
+        warnings.warn(
+        f"T_A has a maximum value of 1024 for SyevdMg, received T_A={T_A}, T_A is lowered to 1024",
+        JaxMgWarning,
+        stacklevel=2,
         )
+        T_A = 1024
+        
     axis_name = in_specs._partitions[0]
     N_rows, N = a.shape
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+# Register the 'mpmd' marker for pytest
+def pytest_configure(config):
+    config.addinivalue_line("markers", "mpmd: mark test as mpmd-related")
 def pytest_collection_modifyitems(config, items):
     selected = []
     deselected = []

--- a/tests/cpu_only/test_potrs_interface.py
+++ b/tests/cpu_only/test_potrs_interface.py
@@ -9,23 +9,6 @@ from jax.sharding import PartitionSpec as P
 from jaxmg import potrs
 
 
-def test_in_specs_not_sequence_raises_assertion():
-    A = jnp.eye(4)
-    b = jnp.ones((4, 1))
-    T_A = 1
-    mesh = jax.make_mesh((jax.local_device_count(),), ("x",))
-    with pytest.raises(AssertionError, match="expected `in_specs` to be a tuple or list"):
-        potrs(A, b, T_A, mesh=mesh, in_specs=P(None, "x"))
-
-
-def test_in_specs_wrong_length_raises_assertion():
-    A = jnp.eye(4)
-    b = jnp.ones((4, 1))
-    T_A = 1
-    mesh = jax.make_mesh((jax.local_device_count(),), ("x",))
-    # single-element tuple should trigger the length assertion
-    with pytest.raises(AssertionError, match="expected two `in_specs`"):
-        potrs(A, b, T_A, mesh=mesh, in_specs=(P("x", None),))
 def test_spec_a_valueerror_when_first_none_or_second_not_none():
     A = jnp.eye(4)
     b = jnp.ones((4, 1))
@@ -33,19 +16,10 @@ def test_spec_a_valueerror_when_first_none_or_second_not_none():
     mesh = jax.make_mesh((jax.local_device_count(),), ("x",))
     # First entry None -> invalid
     with pytest.raises(ValueError, match="A must be sharded along the columns"):
-        potrs(A, b, T_A, mesh=mesh, in_specs=(P(None, "x"), P(None, None)))
+        potrs(A, b, T_A, mesh=mesh, in_specs=(P(None, "x"),))
     # Second entry not None -> invalid
     with pytest.raises(ValueError, match="A must be sharded along the columns"):
-        potrs(A, b, T_A, mesh=mesh, in_specs=(P("x", "y"), P(None, None)))
-
-
-def test_spec_b_valueerror_when_not_replicated():
-    A = jnp.eye(4)
-    b = jnp.ones((4, 1))
-    T_A = 1
-    mesh = jax.make_mesh((jax.local_device_count(),), ("x",))
-    with pytest.raises(ValueError, match="b must be replicated along all shards"):
-        potrs(A, b, T_A, mesh=mesh, in_specs=(P("x", None), P("x", None)))
+        potrs(A, b, T_A, mesh=mesh, in_specs=(P("x", "y"), ))
 
 
 def test_shape_mismatch_raises_assertion():
@@ -54,7 +28,7 @@ def test_shape_mismatch_raises_assertion():
     T_A = 1
     mesh = jax.make_mesh((jax.local_device_count(),), ("x",))
     with pytest.raises(AssertionError, match="A and b must have the same number of columns"):
-        potrs(A, b, T_A, mesh=mesh, in_specs=(P("x", None), P(None, None)))
+        potrs(A, b, T_A, mesh=mesh, in_specs=(P("x", None), ))
 
 
 def test_a_1d_raises_indexerror():
@@ -66,13 +40,13 @@ def test_a_1d_raises_indexerror():
     T_A = 1
     mesh = jax.make_mesh((jax.local_device_count(),), ("x",))
     with pytest.raises(IndexError):
-        potrs(A, b, T_A, mesh=mesh, in_specs=(P("x", None), P(None, None)))
+        potrs(A, b, T_A, mesh=mesh, in_specs=(P("x", None), ))
 
 
 def test_b_1d_raises_assertion():
     A = jnp.eye(4)
-    b = jnp.ones((4,))
+    b = jnp.ones((4,3,1))
     T_A = 1
     mesh = jax.make_mesh((jax.local_device_count(),), ("x",))
-    with pytest.raises(AssertionError, match="b must be a 2D array"):
-        potrs(A, b, T_A, mesh=mesh, in_specs=(P("x", None), P(None, None)))
+    with pytest.raises(AssertionError, match="b must be a 1D or 2D array."):
+        potrs(A, b, T_A, mesh=mesh, in_specs=(P("x", None), ))

--- a/tests/cpu_only/test_syevd_interface.py
+++ b/tests/cpu_only/test_syevd_interface.py
@@ -12,7 +12,7 @@ jax.config.update("jax_enable_x64", True)
 import jax.numpy as jnp
 from jax.sharding import PartitionSpec as P
 from jaxmg import syevd
-
+from jaxmg.utils import JaxMgWarning
 
 # These tests exercise the argument-validation paths in `syevd` and avoid
 # invoking the native FFI. They match the current implementation in
@@ -65,5 +65,5 @@ def test_T_A_too_large_raises_valueerror():
     a = jnp.eye(4)
     T_A = 2048
     mesh = mesh_for_tests()
-    with pytest.raises(ValueError, match="T_A has a maximum value of 1024"):
+    with pytest.warns(JaxMgWarning, match="T_A has a maximum value of 1024"):
         syevd(a, T_A, mesh, (P("x", None),))

--- a/tests/mpmd/run_potri.py
+++ b/tests/mpmd/run_potri.py
@@ -77,6 +77,7 @@ def cusolver_solve_arange(N, T_A, dtype):
     _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
 
     out = jitted_potri(_A.copy(), T_A)
+    out.block_until_ready()
     expected_out = jnp.diag(1.0 / (jnp.arange(N, dtype=dtype) + 1))
     assert jnp.allclose(out, expected_out)
 
@@ -92,6 +93,7 @@ def cusolver_solve_psd(N, T_A, dtype):
     _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
 
     out = jitted_potri(_A.copy(), T_A)
+    out.block_until_ready()
     assert jnp.allclose(A.conj().T, A)
     norm_potri = jnp.linalg.norm(A @ out - jnp.eye(N, dtype=dtype))
     norm_lax = jnp.linalg.norm(A @ expected_out - jnp.eye(N, dtype=dtype))

--- a/tests/mpmd/run_potri.py
+++ b/tests/mpmd/run_potri.py
@@ -129,6 +129,21 @@ def cusolver_solve_non_symm(N, T_A, dtype):
     assert jnp.all(jnp.isnan(out))
 
 
+def cusolver_potri_loop_shm(N, T_A, dtype):
+    T_A = 1
+    dtype = jnp.float64
+    A = random_psd(N, dtype=dtype, seed=5678)
+
+    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+    fd_start = len(os.listdir("/proc/self/fd"))
+    for i in range(100):
+        print(i, len(os.listdir("/proc/self/fd")))
+        out = jitted_potri(_A, T_A)
+        out.block_until_ready()
+    fd_end = len(os.listdir("/proc/self/fd"))
+    assert fd_end - fd_start < 100
+
+
 def _build_registry() -> Dict[str, Callable]:
     # Map test names to callables that accept (N, T_A, dtype)
     return {
@@ -136,6 +151,7 @@ def _build_registry() -> Dict[str, Callable]:
         "non_psd": cusolver_solve_non_psd,
         "non_symm": cusolver_solve_non_symm,
         "psd": cusolver_solve_psd,
+        "loop_shm": cusolver_potri_loop_shm,
     }
 
 

--- a/tests/mpmd/run_potrs.py
+++ b/tests/mpmd/run_potrs.py
@@ -43,9 +43,10 @@ mesh = jax.make_mesh((jax.device_count(),), ("x",))
 from jaxmg import potrs, potrs_shardmap_ctx
 from jaxmg.utils import random_psd
 
+
 @partial(jax.jit, static_argnames=("_T_A",))
 def jitted_potrs(_a, _b, _T_A):
-    out = partial(potrs, mesh=mesh, in_specs=(P("x", None), P(None, None)), pad=True)(
+    out = partial(potrs, mesh=mesh, in_specs=(P("x", None),), pad=True)(
         _a, _b, _T_A
     )
     return out
@@ -54,7 +55,11 @@ def jitted_potrs(_a, _b, _T_A):
 @partial(jax.jit, static_argnames=("_T_A",))
 def jitted_potrs_status(_a, _b, _T_A):
     out = partial(
-        potrs, mesh=mesh, in_specs=(P("x", None), P(None, None)), pad=True, return_status=True
+        potrs,
+        mesh=mesh,
+        in_specs=(P("x", None), ),
+        pad=True,
+        return_status=True,
     )(_a, _b, _T_A)
     return out
 
@@ -134,6 +139,23 @@ def cusolver_solve_non_symm(N, T_A, dtype):
     assert jnp.all(jnp.isnan(out))
 
 
+def cusolver_potrs_loop_shm(N, T_A, dtype):
+    T_A = 1
+    dtype = jnp.float64
+    A = random_psd(N, dtype=dtype, seed=5678)
+    b = jnp.arange(N, dtype=dtype)
+
+    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+    _b = jax.device_put(b, NamedSharding(mesh, P(None)))
+    fd_start = len(os.listdir("/proc/self/fd"))
+    for i in range(100):
+        print(i, len(os.listdir("/proc/self/fd")))
+        out = jitted_potrs(_A, _b, T_A)
+        out.block_until_ready()
+    fd_end = len(os.listdir("/proc/self/fd"))
+    assert fd_end - fd_start < 100
+
+
 def _build_registry() -> Dict[str, Callable]:
     # Map test names to callables that accept (N, T_A, dtype)
     return {
@@ -141,19 +163,20 @@ def _build_registry() -> Dict[str, Callable]:
         "non_psd": cusolver_solve_non_psd,
         "non_symm": cusolver_solve_non_symm,
         "psd": cusolver_solve_psd,
+        "loop_shm": cusolver_potrs_loop_shm,
     }
 
 
 def main(argv: List[str]):
     # Single-task only: expect arguments
     # run_potrs.py <coord_addr> <proc_id> <num_procs> <test_name> <dtype_name>
-    
+
     task_name = argv[4]
     task_dtype_name = argv[5]
     registry = _build_registry()
 
     # Parameter grid metadata (for discover message)
-    ndev= len(devices)
+    ndev = len(devices)
     dtypes = [jnp.float32, jnp.float64, jnp.complex64, jnp.complex128]
     N_list = list(i * ndev for i in [2, 3, 4, 10])
     T_A_list = [1, 2, 3, 5]
@@ -189,7 +212,11 @@ def main(argv: List[str]):
                         "proc": proc_id,
                         "name": task_name,
                         "status": "ok",
-                        "params": {"N": task_N, "T_A": task_T_A, "dtype": task_dtype_name},
+                        "params": {
+                            "N": task_N,
+                            "T_A": task_T_A,
+                            "dtype": task_dtype_name,
+                        },
                     },
                 )
                 n_ok += 1
@@ -201,13 +228,20 @@ def main(argv: List[str]):
                         "proc": proc_id,
                         "name": task_name,
                         "status": "fail",
-                        "params": {"N": task_N, "T_A": task_T_A, "dtype": task_dtype_name},
+                        "params": {
+                            "N": task_N,
+                            "T_A": task_T_A,
+                            "dtype": task_dtype_name,
+                        },
                         "traceback": tb,
                     },
                 )
                 n_fail += 1
 
-            _println("MPTEST_SUMMARY", {"proc": proc_id, "ok": n_ok, "fail": n_fail, "total": n_ok + n_fail})
+            _println(
+                "MPTEST_SUMMARY",
+                {"proc": proc_id, "ok": n_ok, "fail": n_fail, "total": n_ok + n_fail},
+            )
             return 0
 
 

--- a/tests/mpmd/run_potrs.py
+++ b/tests/mpmd/run_potrs.py
@@ -83,6 +83,7 @@ def cusolver_solve_arange(N, T_A, dtype):
     _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
     _b = jax.device_put(b, NamedSharding(mesh, P(None, None)))
     out = jitted_potrs(_A.copy(), _b.copy(), T_A)
+    out.block_until_ready()
     expected_out = 1.0 / (jnp.arange(N, dtype=dtype) + 1)
     assert jnp.allclose(out.flatten(), expected_out)
     out_no_shm, _ = jitted_potrs_no_shardmap(_A.copy(), _b.copy(), T_A)
@@ -99,6 +100,7 @@ def cusolver_solve_psd(N, T_A, dtype):
     _b = jax.device_put(b, NamedSharding(mesh, P(None, None)))
 
     out = jitted_potrs(_A.copy(), _b.copy(), T_A)
+    out.block_until_ready()
     norm_scipy = jnp.linalg.norm(b - A @ expected_out)
     norm_potrf = jnp.linalg.norm(b - A @ out)
     print(norm_scipy, norm_potrf)

--- a/tests/mpmd/run_syevd.py
+++ b/tests/mpmd/run_syevd.py
@@ -90,6 +90,8 @@ def cusolver_solve_arange(N, T_A, dtype):
     # Make mesh and place data
     _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
     eigenvalues, V = jitted_syevd(_A.copy(), T_A)
+    eigenvalues.block_until_ready()
+    V.block_until_ready()
     assert jnp.allclose(eigenvalues_expected, eigenvalues)
     eigenvalues_VtAV = jnp.diag(V @ A @ V.T)
     assert jnp.allclose(eigenvalues_VtAV, eigenvalues_expected)
@@ -103,6 +105,8 @@ def cusolver_solve_psd(N, T_A, dtype):
     # Make mesh and place data
     _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
     eigenvalues, V = jitted_syevd(_A.copy(), T_A)
+    eigenvalues.block_until_ready()
+    V.block_until_ready()
     norm_syevd = jnp.linalg.norm(V @ A - jnp.diag(eigenvalues) @ V.T)
     norm_lax = jnp.linalg.norm(
         V_expected @ A - jnp.diag(eigenvalues_expected) @ V_expected.T
@@ -118,6 +122,7 @@ def cusolver_solve_arange_no_V(N, T_A, dtype):
     # Make mesh and place data
     _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
     eigenvalues = jitted_syevd_no_V(_A.copy(), T_A)
+    eigenvalues.block_until_ready()
     assert jnp.allclose(eigenvalues_expected, eigenvalues)
     eigenvalues_no_shm, _ = jitted_syevd_no_V_no_shardmap(_A.copy(), T_A)
     assert jnp.allclose(eigenvalues_expected, eigenvalues_no_shm)
@@ -129,6 +134,7 @@ def cusolver_solve_psd_no_V(N, T_A, dtype):
     # Make mesh and place data
     _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
     eigenvalues = jitted_syevd_no_V(_A.copy(), T_A)
+    eigenvalues.block_until_ready()
     assert jnp.allclose(eigenvalues, eigenvalues_expected, rtol=10, atol=0.0)
     eigenvalues_no_shm, _ = jitted_syevd_no_V_no_shardmap(_A.copy(), T_A)
     assert jnp.allclose(eigenvalues_expected, eigenvalues_no_shm, rtol=10, atol=0.0)

--- a/tests/mpmd/run_syevd.py
+++ b/tests/mpmd/run_syevd.py
@@ -134,6 +134,36 @@ def cusolver_solve_psd_no_V(N, T_A, dtype):
     assert jnp.allclose(eigenvalues_expected, eigenvalues_no_shm, rtol=10, atol=0.0)
 
 
+def cusolver_syevd_loop_shm(N, T_A, dtype):
+    T_A = 1
+    dtype = jnp.float64
+    A = random_psd(N, dtype=dtype, seed=5678)
+
+    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+    fd_start = len(os.listdir("/proc/self/fd"))
+    for i in range(100):
+        print(i, len(os.listdir("/proc/self/fd")))
+        out,_ = jitted_syevd(_A, T_A)
+        out.block_until_ready()
+    fd_end = len(os.listdir("/proc/self/fd"))
+    assert fd_end - fd_start < 100
+
+
+def cusolver_syevd_no_V_loop_shm(N, T_A, dtype):
+    T_A = 1
+    dtype = jnp.float64
+    A = random_psd(N, dtype=dtype, seed=5678)
+
+    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+    fd_start = len(os.listdir("/proc/self/fd"))
+    for i in range(100):
+        print(i, len(os.listdir("/proc/self/fd")))
+        out = jitted_syevd_no_V(_A, T_A)
+        out.block_until_ready()
+    fd_end = len(os.listdir("/proc/self/fd"))
+    assert fd_end - fd_start < 100
+
+
 def _build_registry() -> Dict[str, Callable]:
     # Map test names to callables that accept (N, T_A, dtype)
     return {
@@ -141,6 +171,8 @@ def _build_registry() -> Dict[str, Callable]:
         "psd": cusolver_solve_psd,
         "arange_no_V": cusolver_solve_arange_no_V,
         "psd_no_V": cusolver_solve_psd_no_V,
+        "loop_shm": cusolver_syevd_loop_shm,
+        "loop_shm_no_V": cusolver_syevd_no_V_loop_shm,
     }
 
 

--- a/tests/mpmd/run_syevd.py
+++ b/tests/mpmd/run_syevd.py
@@ -107,9 +107,9 @@ def cusolver_solve_psd(N, T_A, dtype):
     norm_lax = jnp.linalg.norm(
         V_expected @ A - jnp.diag(eigenvalues_expected) @ V_expected.T
     )
-    assert jnp.isclose(norm_syevd, norm_lax, rtol=10, atol=1e-8)
+    assert jnp.isclose(norm_syevd, norm_lax, rtol=10, atol=0.0)
     eigenvalues_no_shm, V_no_shm, _ = jitted_syevd_no_shardmap(_A.copy(), T_A)
-    assert jnp.allclose(eigenvalues_expected, eigenvalues_no_shm, rtol=10, atol=1e-10)
+    assert jnp.allclose(eigenvalues_expected, eigenvalues_no_shm, rtol=10, atol=0.0)
 
 
 def cusolver_solve_arange_no_V(N, T_A, dtype):

--- a/tests/mpmd/test_launch_2d_grid_reduce.py
+++ b/tests/mpmd/test_launch_2d_grid_reduce.py
@@ -1,3 +1,5 @@
+import pytest
+pytestmark = pytest.mark.mpmd
 import os
 import sys
 import subprocess

--- a/tests/mpmd/test_launch_potri.py
+++ b/tests/mpmd/test_launch_potri.py
@@ -1,3 +1,5 @@
+import pytest
+pytestmark = pytest.mark.mpmd
 from pathlib import Path
 
 import pytest
@@ -8,42 +10,37 @@ from mpmd_helper import run_mpmd_test
 HERE = Path(__file__).parent
 MP_TEST = HERE / "run_potri.py"
 
-if len(jax.devices("gpu")) == 0:
-    pytest.skip("No GPUs found. Skipping")
+platforms = set(d.platform for d in jax.devices())
+if "gpu" not in platforms:
+    pytest.skip("No GPUs found. Skipping", allow_module_level=True)
+else:
+    gpu_count = jax.device_count()
+
+    # Only run for the currently visible GPU count; the original test enumerated
+    # requested_procs=(1,2,3,4) and skipped when mismatched. Here we parametrize
+    # only for the local visible gpu count to keep collection stable.
+    requested_procs_list = (gpu_count,)
 
 
-# Build the parameter grid once at collection time and parametrize each
-# (requested_procs, test_name, N, T_A, dtype) as a separate pytest test so
-# each task appears individually in pytest's summary.
-gpu_count = jax.device_count("gpu")
-if gpu_count == 0:
-    pytest.skip("No GPUs found. Skipping")
-
-# Only run for the currently visible GPU count; the original test enumerated
-# requested_procs=(1,2,3,4) and skipped when mismatched. Here we parametrize
-# only for the local visible gpu count to keep collection stable.
-requested_procs_list = (gpu_count,)
+    dtypes = ["float32", "float64", "complex64", "complex128"]
+    test_names = ["arange", "non_psd", "non_symm", "psd"]
 
 
-dtypes = ["float32", "float64", "complex64", "complex128"]
-test_names = ["arange", "non_psd", "non_symm", "psd"]
+    tasks = []
+    task_ids = []
+    for requested_procs in requested_procs_list:
+        for name in test_names:
+            for dtype_name in dtypes:
+                tasks.append((requested_procs, name, dtype_name))
+                task_ids.append(f"{name}-{dtype_name}-p{requested_procs}")
 
 
-tasks = []
-task_ids = []
-for requested_procs in requested_procs_list:
-    for name in test_names:
-        for dtype_name in dtypes:
-            tasks.append((requested_procs, name, dtype_name))
-            task_ids.append(f"{name}-{dtype_name}-p{requested_procs}")
+    @pytest.mark.parametrize(
+        "requested_procs,name, dtype_name",
+        tasks,
+        ids=task_ids,
+    )
+    def test_task_mpmd_potri(requested_procs, name, dtype_name):
+        """Run a single distributed potri task as an individual pytest test."""
 
-
-@pytest.mark.parametrize(
-    "requested_procs,name, dtype_name",
-    tasks,
-    ids=task_ids,
-)
-def test_task_mpmd_potri(requested_procs, name, dtype_name):
-    """Run a single distributed potri task as an individual pytest test."""
-
-    run_mpmd_test(MP_TEST, requested_procs, name, dtype_name)
+        run_mpmd_test(MP_TEST, requested_procs, name, dtype_name)

--- a/tests/mpmd/test_launch_potrs.py
+++ b/tests/mpmd/test_launch_potrs.py
@@ -1,3 +1,5 @@
+import pytest
+pytestmark = pytest.mark.mpmd
 from pathlib import Path
 
 import pytest
@@ -8,40 +10,35 @@ from mpmd_helper import run_mpmd_test
 HERE = Path(__file__).parent
 MP_TEST = HERE / "run_potrs.py"
 
-if len(jax.devices("gpu")) == 0:
-    pytest.skip("No GPUs found. Skipping")
+platforms = set(d.platform for d in jax.devices())
+if "gpu" not in platforms:
+    pytest.skip("No GPUs found. Skipping", allow_module_level=True)
+else:
+    gpu_count = jax.device_count()
+
+    # Only run for the currently visible GPU count; the original test enumerated
+    # requested_procs=(1,2,3,4) and skipped when mismatched. Here we parametrize
+    # only for the local visible gpu count to keep collection stable.
+    requested_procs_list = (gpu_count,)
+
+    dtypes = ["float32", "float64", "complex64", "complex128"]
+    test_names = ["arange", "non_psd", "non_symm", "psd"]
+
+    tasks = []
+    task_ids = []
+    for requested_procs in requested_procs_list:
+        for name in test_names:
+            for dtype_name in dtypes:
+                tasks.append((requested_procs, name, dtype_name))
+                task_ids.append(f"{name}-{dtype_name}-p{requested_procs}")
 
 
-# Build the parameter grid once at collection time and parametrize each
-# (requested_procs, test_name, N, T_A, dtype) as a separate pytest test so
-# each task appears individually in pytest's summary.
-gpu_count = jax.device_count("gpu")
-if gpu_count == 0:
-    pytest.skip("No GPUs found. Skipping")
+    @pytest.mark.parametrize(
+        "requested_procs,name, dtype_name",
+        tasks,
+        ids=task_ids,
+    )
+    def test_task_mpmd(requested_procs, name, dtype_name):
+        """Run a single distributed potrs task as an individual pytest test."""
 
-# Only run for the currently visible GPU count; the original test enumerated
-# requested_procs=(1,2,3,4) and skipped when mismatched. Here we parametrize
-# only for the local visible gpu count to keep collection stable.
-requested_procs_list = (gpu_count,)
-
-dtypes = ["float32", "float64", "complex64", "complex128"]
-test_names = ["arange", "non_psd", "non_symm", "psd"]
-
-tasks = []
-task_ids = []
-for requested_procs in requested_procs_list:
-    for name in test_names:
-        for dtype_name in dtypes:
-            tasks.append((requested_procs, name, dtype_name))
-            task_ids.append(f"{name}-{dtype_name}-p{requested_procs}")
-
-
-@pytest.mark.parametrize(
-    "requested_procs,name, dtype_name",
-    tasks,
-    ids=task_ids,
-)
-def test_task_mpmd(requested_procs, name, dtype_name):
-    """Run a single distributed potrs task as an individual pytest test."""
-
-    run_mpmd_test(MP_TEST, requested_procs, name, dtype_name)
+        run_mpmd_test(MP_TEST, requested_procs, name, dtype_name)

--- a/tests/mpmd/test_launch_syevd.py
+++ b/tests/mpmd/test_launch_syevd.py
@@ -1,3 +1,5 @@
+import pytest
+pytestmark = pytest.mark.mpmd
 from pathlib import Path
 
 import pytest
@@ -8,40 +10,35 @@ from mpmd_helper import run_mpmd_test
 HERE = Path(__file__).parent
 MP_TEST = HERE / "run_syevd.py"
 
-if len(jax.devices("gpu")) == 0:
-    pytest.skip("No GPUs found. Skipping")
+platforms = set(d.platform for d in jax.devices())
+if "gpu" not in platforms:
+    pytest.skip("No GPUs found. Skipping", allow_module_level=True)
+else:
+    gpu_count = jax.device_count()
+
+    # Only run for the currently visible GPU count; the original test enumerated
+    # requested_procs=(1,2,3,4) and skipped when mismatched. Here we parametrize
+    # only for the local visible gpu count to keep collection stable.
+    REQUESTED_PROCS_LIST = (gpu_count,)
+
+    DTYPES = ["float32", "float64", "complex64", "complex128"]
+    TEST_NAMES = ["arange", "psd", "arange_no_V", "psd_no_V"]
+
+    TASKS = []
+    TASK_IDS = []
+    for requested_procs in REQUESTED_PROCS_LIST:
+        for name in TEST_NAMES:
+            for dtype_name in DTYPES:
+                TASKS.append((requested_procs, name, dtype_name))
+                TASK_IDS.append(f"{name}-{dtype_name}-p{requested_procs}")
 
 
-# Build the parameter grid once at collection time and parametrize each
-# (requested_procs, test_name, N, T_A, dtype) as a separate pytest test so
-# each task appears individually in pytest's summary.
-GPU_COUNT = jax.device_count("gpu")
-if GPU_COUNT == 0:
-    pytest.skip("No GPUs found. Skipping")
+    @pytest.mark.parametrize(
+        "requested_procs,name, dtype_name",
+        TASKS,
+        ids=TASK_IDS,
+    )
+    def test_task_mpmd_syevd(requested_procs, name, dtype_name):
+        """Run a single distributed syevd task as an individual pytest test."""
 
-# Only run for the currently visible GPU count; the original test enumerated
-# requested_procs=(1,2,3,4) and skipped when mismatched. Here we parametrize
-# only for the local visible gpu count to keep collection stable.
-REQUESTED_PROCS_LIST = (GPU_COUNT,)
-
-DTYPES = ["float32", "float64", "complex64", "complex128"]
-TEST_NAMES = ["arange", "psd", "arange_no_V", "psd_no_V"]
-
-TASKS = []
-TASK_IDS = []
-for requested_procs in REQUESTED_PROCS_LIST:
-    for name in TEST_NAMES:
-        for dtype_name in DTYPES:
-            TASKS.append((requested_procs, name, dtype_name))
-            TASK_IDS.append(f"{name}-{dtype_name}-p{requested_procs}")
-
-
-@pytest.mark.parametrize(
-    "requested_procs,name, dtype_name",
-    TASKS,
-    ids=TASK_IDS,
-)
-def test_task_mpmd_syevd(requested_procs, name, dtype_name):
-    """Run a single distributed syevd task as an individual pytest test."""
-
-    run_mpmd_test(MP_TEST, requested_procs, name, dtype_name)
+        run_mpmd_test(MP_TEST, requested_procs, name, dtype_name)

--- a/tests/spmd/test_cyclic_1d.py
+++ b/tests/spmd/test_cyclic_1d.py
@@ -36,6 +36,7 @@ def cusolver_solve_arange(N, T_A, dtype):
     out = jax.jit(
         partial(cyclic_1d, mesh=mesh, in_specs=(P("x", None),)), static_argnums=1
     )(A, T_A=T_A)
+    out.block_until_ready()
     verify_cyclic(A_before, out, T_A=T_A)
 
 
@@ -47,6 +48,7 @@ def cusolver_solve_psd(N, T_A, dtype):
     out = jax.jit(
         partial(cyclic_1d, mesh=mesh, in_specs=(P("x", None),)), static_argnums=1
     )(_A, T_A=T_A)
+    out.block_until_ready()
     verify_cyclic(A_before, out, T_A=T_A)
 
 

--- a/tests/spmd/test_cyclic_1d.py
+++ b/tests/spmd/test_cyclic_1d.py
@@ -16,11 +16,11 @@ from jaxmg import cyclic_1d, verify_cyclic
 from jaxmg.utils import random_psd
 from functools import partial
 
-if len(jax.devices("gpu"))==0:
-    pytest.skip("No GPUs found. Skipping test...")
+platforms = set(d.platform for d in jax.devices())
+if "gpu" not in platforms:
+    pytest.skip("No GPUs found. Skipping", allow_module_level=True)
     
-devices = [d for d in jax.devices() if d.platform == "gpu"]
-ndev = len(devices)
+ndev = jax.device_count()
 mesh = jax.make_mesh((ndev,), ("x",))
 # Test cases
 N_list = list(i * ndev for i in [2, 3, 4, 10])

--- a/tests/spmd/test_examples.py
+++ b/tests/spmd/test_examples.py
@@ -13,12 +13,11 @@ from functools import partial
 import time
 import matplotlib.pyplot as plt
 
-if len(jax.devices("gpu"))==0:
-    pytest.skip("No GPUs found. Skipping test...")
+platforms = set(d.platform for d in jax.devices())
+if "gpu" not in platforms:
+    pytest.skip("No GPUs found. Skipping", allow_module_level=True)
     
-devices = [d for d in jax.devices() if d.platform == "gpu"]
-ndev = len(devices)
-gpu_count = jax.device_count("gpu")
+ndev = jax.device_count()
 
 
 def test_block_cyclic_data_layout_plot_1():
@@ -29,8 +28,8 @@ def test_block_cyclic_data_layout_plot_1():
 
 
 def test_block_cyclic_data_layout_syevd_timing():
-    if gpu_count != 3:
-        pytest.skip(f"Only testing when 4 GPUS are detected, round only {gpu_count}")
+    if ndev != 3:
+        pytest.skip(f"Only testing when 4 GPUS are detected, round only {ndev}")
 
     print(f"Devices: {jax.devices()}")
     # Assumes we have at least one GPU available

--- a/tests/spmd/test_examples.py
+++ b/tests/spmd/test_examples.py
@@ -16,119 +16,116 @@ import matplotlib.pyplot as plt
 platforms = set(d.platform for d in jax.devices())
 if "gpu" not in platforms:
     pytest.skip("No GPUs found. Skipping", allow_module_level=True)
-    
-ndev = jax.device_count()
+else:
+
+    def test_block_cyclic_data_layout_plot_1():
+        N = 100
+        T_A = 7
+        ndev = 4
+        plot_block_to_cyclic(N, T_A, ndev)
 
 
-def test_block_cyclic_data_layout_plot_1():
-    N = 100
-    T_A = 7
-    ndev = 4
-    plot_block_to_cyclic(N, T_A, ndev)
+    def test_block_cyclic_data_layout_syevd_timing():
+        ndev = jax.device_count()
+        if ndev != 3:
+            pytest.skip(f"Only testing when 4 GPUS are detected, round only {ndev}")
+
+        print(f"Devices: {jax.devices()}")
+        # Assumes we have at least one GPU available
+        devices = jax.devices("gpu")
+        N = 3**7
+        print(f"N={N}")
+        dtype = jnp.float64
+        # Create random
+        A = jax.random.normal(key=jax.random.key(100), shape=(N, N), dtype=dtype)
+        A = A + A.T
+        b = jnp.ones((N, 1), dtype=dtype)
+        ndev = len(devices)
+        # Make mesh and place data (rows sharded)
+        mesh = jax.make_mesh((ndev,), ("x",))
+        # Call syevd
+        times = []
+        tile_sizes = [2, 16, 32, 128, 256]
+        for T_A in tile_sizes:
+            Adev = jax.device_put(A, NamedSharding(mesh, P("x", None))).block_until_ready()
+            start = time.time()
+            ev, V, status = syevd(
+                A, T_A=T_A, mesh=mesh, in_specs=(P("x", None),), return_status=True
+            )
+            ev.block_until_ready()
+            V.block_until_ready()
+            end = time.time()
+            times.append(end - start)
+            print(f"Status {status} - Elapsed time {end - start:1.5f}[s]")
+        plt.plot(tile_sizes, times, marker=".", markersize=10)
+        plt.xlabel("T_A")
+        plt.ylabel("Time [s]")
+        plt.grid()
 
 
-def test_block_cyclic_data_layout_syevd_timing():
-    if ndev != 3:
-        pytest.skip(f"Only testing when 4 GPUS are detected, round only {ndev}")
-
-    print(f"Devices: {jax.devices()}")
-    # Assumes we have at least one GPU available
-    devices = jax.devices("gpu")
-    N = 3**7
-    print(f"N={N}")
-    dtype = jnp.float64
-    # Create random
-    A = jax.random.normal(key=jax.random.key(100), shape=(N, N), dtype=dtype)
-    A = A + A.T
-    b = jnp.ones((N, 1), dtype=dtype)
-    ndev = len(devices)
-    # Make mesh and place data (rows sharded)
-    mesh = jax.make_mesh((ndev,), ("x",))
-    # Call syevd
-    times = []
-    tile_sizes = [2, 16, 32, 128, 256]
-    for T_A in tile_sizes:
-        Adev = jax.device_put(A, NamedSharding(mesh, P("x", None))).block_until_ready()
-        start = time.time()
-        ev, V, status = syevd(
-            A, T_A=T_A, mesh=mesh, in_specs=(P("x", None),), return_status=True
-        )
-        ev.block_until_ready()
-        V.block_until_ready()
-        end = time.time()
-        times.append(end - start)
-        print(f"Status {status} - Elapsed time {end - start:1.5f}[s]")
-    plt.plot(tile_sizes, times, marker=".", markersize=10)
-    plt.xlabel("T_A")
-    plt.ylabel("Time [s]")
-    plt.grid()
+    def test_block_cyclic_data_layout_plot_2():
+        N = 3**9
+        T_A = 3**6
+        ndev = 3
+        plot_block_to_cyclic(N, T_A, ndev)
 
 
-def test_block_cyclic_data_layout_plot_2():
-    N = 3**9
-    T_A = 3**6
-    ndev = 3
-    plot_block_to_cyclic(N, T_A, ndev)
+    def test_potrs_examples():
+        print(f"Devices: {jax.devices()}")
+        # Assumes we have at least one GPU available
+        ndev = jax.device_count()
+        N = 4 * ndev
+        T_A = 3
+        dtype = jnp.float64
+        # Create diagonal matrix and `b` all equal to one
+        A = jnp.diag(jnp.arange(N, dtype=dtype) + 1)
+        b = jnp.ones((N, 1), dtype=dtype)
+        # Make mesh and place data (rows sharded)
+        mesh = jax.make_mesh((ndev,), ("x",))
+        A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+        b = jax.device_put(b, NamedSharding(mesh, P(None, None)))
+        # Call potrs
+        out = potrs(A, b, T_A=T_A, mesh=mesh, in_specs=(P("x", None),))
+        print(out.block_until_ready())
+        expected_out = 1.0 / (jnp.arange(N, dtype=dtype) + 1)
+        assert jnp.allclose(out.flatten(), expected_out)
 
 
-def test_potrs_examples():
-    print(f"Devices: {jax.devices()}")
-    # Assumes we have at least one GPU available
-    devices = jax.devices("gpu")
-    N = 4 * len(devices)
-    T_A = 3
-    dtype = jnp.float64
-    # Create diagonal matrix and `b` all equal to one
-    A = jnp.diag(jnp.arange(N, dtype=dtype) + 1)
-    b = jnp.ones((N, 1), dtype=dtype)
-    ndev = len(devices)
-    # Make mesh and place data (rows sharded)
-    mesh = jax.make_mesh((ndev,), ("x",))
-    A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    b = jax.device_put(b, NamedSharding(mesh, P(None, None)))
-    # Call potrs
-    out = potrs(A, b, T_A=T_A, mesh=mesh, in_specs=(P("x", None),))
-    print(out.block_until_ready())
-    expected_out = 1.0 / (jnp.arange(N, dtype=dtype) + 1)
-    assert jnp.allclose(out.flatten(), expected_out)
+    def test_potrs_examples_shm_ctx():
+        print(f"Devices: {jax.devices()}")
 
+        def shard_mapped_fn(_a, _b, _T_A):
+            _a = _a * (
+                jax.lax.axis_index("x") + 1
+            )  # Multiply each shard with the axis number
+            return potrs_shardmap_ctx(_a, _b, _T_A)
 
-def test_potrs_examples_shm_ctx():
-    print(f"Devices: {jax.devices()}")
+        def my_fn(_a, _b, _T_A):
+            out = jax.shard_map(
+                partial(shard_mapped_fn, _T_A=_T_A),
+                mesh=mesh,
+                in_specs=(P("x", None), P(None, None)),
+                out_specs=(P(None, None), P(None)),  # we always return a status.
+                check_vma=False,
+            )(_a, _b)
+            return out
 
-    def shard_mapped_fn(_a, _b, _T_A):
-        _a = _a * (
-            jax.lax.axis_index("x") + 1
-        )  # Multiply each shard with the axis number
-        return potrs_shardmap_ctx(_a, _b, _T_A)
-
-    def my_fn(_a, _b, _T_A):
-        out = jax.shard_map(
-            partial(shard_mapped_fn, _T_A=_T_A),
-            mesh=mesh,
-            in_specs=(P("x", None), P(None, None)),
-            out_specs=(P(None, None), P(None)),  # we always return a status.
-            check_vma=False,
-        )(_a, _b)
-        return out
-
-    # Assumes we have at least one GPU available
-    devices = jax.devices("gpu")
-    ndev = len(devices)
-    N = 6 * ndev
-    T_A = 1
-    dtype = jnp.float32
-    # Create diagonal matrix
-    _A = jnp.eye(N, dtype=dtype)
-    _b = jnp.ones((N, 1), dtype=dtype)
-    # Make mesh and place data (rows sharded)
-    mesh = jax.make_mesh((ndev,), ("x",))
-    A = jax.device_put(_A, NamedSharding(mesh, P("x", None)))
-    b = jax.device_put(_b, NamedSharding(mesh, P(None, None)))
-    # Call potrs
-    out, status = my_fn(A, b, T_A)
-    print(out.block_until_ready())
-    print(f"Solver status: {status}")
-    # compute residual on host
-    b_target = jnp.concatenate([jnp.ones((6,1), dtype=dtype) / i for i in range(1, ndev + 1)], axis=0)
-    assert jnp.allclose(out, b_target, rtol=10, atol=1e-5)
+        # Assumes we have at least one GPU available
+        ndev = jax.device_count()
+        N = 6 * ndev
+        T_A = 1
+        dtype = jnp.float32
+        # Create diagonal matrix
+        _A = jnp.eye(N, dtype=dtype)
+        _b = jnp.ones((N, 1), dtype=dtype)
+        # Make mesh and place data (rows sharded)
+        mesh = jax.make_mesh((ndev,), ("x",))
+        A = jax.device_put(_A, NamedSharding(mesh, P("x", None)))
+        b = jax.device_put(_b, NamedSharding(mesh, P(None, None)))
+        # Call potrs
+        out, status = my_fn(A, b, T_A)
+        print(out.block_until_ready())
+        print(f"Solver status: {status}")
+        # compute residual on host
+        b_target = jnp.concatenate([jnp.ones((6,1), dtype=dtype) / i for i in range(1, ndev + 1)], axis=0)
+        assert jnp.allclose(out, b_target, rtol=10, atol=1e-5)

--- a/tests/spmd/test_examples.py
+++ b/tests/spmd/test_examples.py
@@ -88,7 +88,7 @@ def test_potrs_examples():
     A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
     b = jax.device_put(b, NamedSharding(mesh, P(None, None)))
     # Call potrs
-    out = potrs(A, b, T_A=T_A, mesh=mesh, in_specs=(P("x", None), P(None, None)))
+    out = potrs(A, b, T_A=T_A, mesh=mesh, in_specs=(P("x", None),))
     print(out.block_until_ready())
     expected_out = 1.0 / (jnp.arange(N, dtype=dtype) + 1)
     assert jnp.allclose(out.flatten(), expected_out)

--- a/tests/spmd/test_potri.py
+++ b/tests/spmd/test_potri.py
@@ -160,3 +160,16 @@ def test_cusolver_inplace_check(dtype):
     A_inv = jitted_potri(_A, T_A)
     norm_potri = jnp.linalg.norm(A @ A_inv - jnp.eye(N, dtype=dtype))
     assert jnp.isclose(norm_potri, norm_lax, rtol=10, atol=1e-8)
+
+def test_potri_loop_shm():
+    N = ndev * 2
+    T_A = 1
+    dtype = jnp.float64
+    A = random_psd(N, dtype=dtype, seed=5678)
+    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+    fd_start = len(os.listdir("/proc/self/fd"))
+    for i in range(100):
+        out = jitted_potri(_A,  T_A)
+        out.block_until_ready()
+    fd_end = len(os.listdir("/proc/self/fd"))
+    assert fd_end - fd_start < 100

--- a/tests/spmd/test_potri.py
+++ b/tests/spmd/test_potri.py
@@ -15,161 +15,161 @@ from jaxmg import potri, potri_shardmap_ctx, potri_symmetrize
 from jaxmg.utils import random_psd
 from functools import partial
 
-if len(jax.devices("gpu"))==0:
-    pytest.skip("No GPUs found. Skipping test...")
-    
-devices = [d for d in jax.devices() if d.platform == "gpu"]
-ndev = len(devices)
-mesh = jax.make_mesh((ndev,), ("x",))
-# Test cases
-N_list = list(i * ndev for i in [2, 3, 4, 10])
-T_A_list = [1, 2, 3, 5]
+platforms = set(d.platform for d in jax.devices())
+if "gpu" not in platforms:
+    pytest.skip("No GPUs found. Skipping", allow_module_level=True)
+else:
+    ndev = jax.device_count()
+    mesh = jax.make_mesh((ndev,), ("x",))
+    # Test cases
+    N_list = list(i * ndev for i in [2, 3, 4, 10])
+    T_A_list = [1, 2, 3, 5]
 
 
-@partial(jax.jit, static_argnames=("_T_A",))
-def jitted_potri(_a, _T_A):
-    out = partial(potri, mesh=mesh, in_specs=(P("x", None),), pad=True)(_a, _T_A)
-    return out
+    @partial(jax.jit, static_argnames=("_T_A",))
+    def jitted_potri(_a, _T_A):
+        out = partial(potri, mesh=mesh, in_specs=(P("x", None),), pad=True)(_a, _T_A)
+        return out
 
 
-@partial(jax.jit, static_argnames=("_T_A",))
-def jitted_potri_status(_a, _T_A):
-    out, status = partial(
-        potri, mesh=mesh, in_specs=(P("x", None),), pad=True, return_status=True
-    )(_a, _T_A)
-    return out, status
+    @partial(jax.jit, static_argnames=("_T_A",))
+    def jitted_potri_status(_a, _T_A):
+        out, status = partial(
+            potri, mesh=mesh, in_specs=(P("x", None),), pad=True, return_status=True
+        )(_a, _T_A)
+        return out, status
 
 
-@partial(jax.jit, static_argnames=("_T_A",))
-def jitted_potri_no_shardmap(_a, _T_A):
-    out, status = jax.shard_map(
-        partial(potri_shardmap_ctx, T_A=_T_A),
-        mesh=mesh,
-        in_specs=(P("x", None),),
-        out_specs=(P("x", None), P(None)),
-        check_vma=False,
-    )(_a)
-    return out, status
+    @partial(jax.jit, static_argnames=("_T_A",))
+    def jitted_potri_no_shardmap(_a, _T_A):
+        out, status = jax.shard_map(
+            partial(potri_shardmap_ctx, T_A=_T_A),
+            mesh=mesh,
+            in_specs=(P("x", None),),
+            out_specs=(P("x", None), P(None)),
+            check_vma=False,
+        )(_a)
+        return out, status
 
 
-def cusolver_solve_arange(N, T_A, dtype):
-    A = jnp.diag(jnp.arange(N, dtype=dtype) + 1)
-    # Make mesh and place data
-    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+    def cusolver_solve_arange(N, T_A, dtype):
+        A = jnp.diag(jnp.arange(N, dtype=dtype) + 1)
+        # Make mesh and place data
+        _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
 
-    out = jitted_potri(_A.copy(), T_A)
-    expected_out = jnp.diag(1.0 / (jnp.arange(N, dtype=dtype) + 1))
-    assert jnp.allclose(out, expected_out)
-    expected_out_no_shm, _ = jitted_potri_no_shardmap(_A, T_A)
-    expected_out_no_shm = potri_symmetrize(expected_out_no_shm)
-    assert jnp.allclose(out, expected_out_no_shm)
-
-
-def cusolver_solve_psd(N, T_A, dtype):
-    A = random_psd(N, dtype=dtype, seed=1234)
-    expected_out = jnp.linalg.inv(A)
-    # Make mesh and place data
-    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    out = jitted_potri(_A, T_A)
-    assert jnp.allclose(A.conj().T, A)
-    norm_potri = jnp.linalg.norm(A @ out - jnp.eye(N, dtype=dtype))
-    norm_lax = jnp.linalg.norm(A @ expected_out - jnp.eye(N, dtype=dtype))
-    assert jnp.isclose(norm_potri, norm_lax, rtol=10, atol=1e-8)
-    expected_out_no_shm, _ = jitted_potri_no_shardmap(_A, T_A)
-    expected_out_no_shm = potri_symmetrize(expected_out_no_shm)
-    norm_potri_no_shm = jnp.linalg.norm(
-        A @ expected_out_no_shm - jnp.eye(N, dtype=dtype)
-    )
-    assert jnp.allclose(norm_potri_no_shm, norm_lax, rtol=10, atol=1e-8)
+        out = jitted_potri(_A.copy(), T_A)
+        expected_out = jnp.diag(1.0 / (jnp.arange(N, dtype=dtype) + 1))
+        assert jnp.allclose(out, expected_out)
+        expected_out_no_shm, _ = jitted_potri_no_shardmap(_A, T_A)
+        expected_out_no_shm = potri_symmetrize(expected_out_no_shm)
+        assert jnp.allclose(out, expected_out_no_shm)
 
 
-def cusolver_solve_non_psd(N, T_A, dtype):
-    A = jnp.diag(jnp.arange(N, dtype=dtype) - 1)
-    # Make mesh and place data
-    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    out, status = jitted_potri_status(_A, T_A)
-    status.block_until_ready()
-    out.block_until_ready()
-    assert status == 7
-    assert jnp.all(jnp.isnan(out))
+    def cusolver_solve_psd(N, T_A, dtype):
+        A = random_psd(N, dtype=dtype, seed=1234)
+        expected_out = jnp.linalg.inv(A)
+        # Make mesh and place data
+        _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+        out = jitted_potri(_A, T_A)
+        assert jnp.allclose(A.conj().T, A)
+        norm_potri = jnp.linalg.norm(A @ out - jnp.eye(N, dtype=dtype))
+        norm_lax = jnp.linalg.norm(A @ expected_out - jnp.eye(N, dtype=dtype))
+        assert jnp.isclose(norm_potri, norm_lax, rtol=10, atol=1e-8)
+        expected_out_no_shm, _ = jitted_potri_no_shardmap(_A, T_A)
+        expected_out_no_shm = potri_symmetrize(expected_out_no_shm)
+        norm_potri_no_shm = jnp.linalg.norm(
+            A @ expected_out_no_shm - jnp.eye(N, dtype=dtype)
+        )
+        assert jnp.allclose(norm_potri_no_shm, norm_lax, rtol=10, atol=1e-8)
 
 
-def cusolver_solve_non_symm(N, T_A, dtype):
-    A = jnp.diag(jnp.arange(N, dtype=dtype) + 1)
-    # TODO: For some reason the solver does not fail when we set this to 1.0.
-    A = A.at[0, 1].set(2.0)
-    # Make mesh and place data
-    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    out, status = jitted_potri_status(_A, T_A)
-    status.block_until_ready()
-    out.block_until_ready()
-    assert status == 7
-    assert jnp.all(jnp.isnan(out))
-
-
-@pytest.mark.parametrize(
-    "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
-)
-@pytest.mark.parametrize("T_A", T_A_list)
-@pytest.mark.parametrize("N", N_list)
-def test_cusolver_solve_arange_dev_1(N, T_A, dtype):
-    cusolver_solve_arange(N, T_A, dtype)
-
-
-@pytest.mark.parametrize(
-    "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
-)
-@pytest.mark.parametrize("T_A", T_A_list)
-@pytest.mark.parametrize("N", N_list)
-def test_cusolver_solve_psd_dev_1(N, T_A, dtype):
-    cusolver_solve_psd(N, T_A, dtype)
-
-
-@pytest.mark.parametrize(
-    "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
-)
-@pytest.mark.parametrize("T_A", T_A_list)
-@pytest.mark.parametrize("N", N_list)
-def test_cusolver_solve_non_psd_dev_1(N, T_A, dtype):
-    cusolver_solve_non_psd(N, T_A, dtype)
-
-
-@pytest.mark.parametrize(
-    "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
-)
-@pytest.mark.parametrize("T_A", T_A_list)
-@pytest.mark.parametrize("N", N_list)
-def test_cusolver_solve_non_symm_dev_1(N, T_A, dtype):
-    cusolver_solve_non_symm(N, T_A, dtype)
-
-
-@pytest.mark.parametrize(
-    "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
-)
-def test_cusolver_inplace_check(dtype):
-    N = ndev * 2
-    T_A = 1
-    A = random_psd(N, dtype=dtype, seed=1234)
-    expected_out = jnp.linalg.inv(A)
-    # Make mesh and place data
-    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    A_inv = jitted_potri(_A, T_A)
-    norm_potri = jnp.linalg.norm(A @ A_inv - jnp.eye(N, dtype=dtype))
-    norm_lax = jnp.linalg.norm(A @ expected_out - jnp.eye(N, dtype=dtype))
-    assert jnp.isclose(norm_potri, norm_lax, rtol=10, atol=1e-8)
-    A_inv = jitted_potri(_A, T_A)
-    norm_potri = jnp.linalg.norm(A @ A_inv - jnp.eye(N, dtype=dtype))
-    assert jnp.isclose(norm_potri, norm_lax, rtol=10, atol=1e-8)
-
-def test_potri_loop_shm():
-    N = ndev * 2
-    T_A = 1
-    dtype = jnp.float64
-    A = random_psd(N, dtype=dtype, seed=5678)
-    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    fd_start = len(os.listdir("/proc/self/fd"))
-    for i in range(100):
-        out = jitted_potri(_A,  T_A)
+    def cusolver_solve_non_psd(N, T_A, dtype):
+        A = jnp.diag(jnp.arange(N, dtype=dtype) - 1)
+        # Make mesh and place data
+        _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+        out, status = jitted_potri_status(_A, T_A)
+        status.block_until_ready()
         out.block_until_ready()
-    fd_end = len(os.listdir("/proc/self/fd"))
-    assert fd_end - fd_start < 100
+        assert status == 7
+        assert jnp.all(jnp.isnan(out))
+
+
+    def cusolver_solve_non_symm(N, T_A, dtype):
+        A = jnp.diag(jnp.arange(N, dtype=dtype) + 1)
+        # TODO: For some reason the solver does not fail when we set this to 1.0.
+        A = A.at[0, 1].set(2.0)
+        # Make mesh and place data
+        _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+        out, status = jitted_potri_status(_A, T_A)
+        status.block_until_ready()
+        out.block_until_ready()
+        assert status == 7
+        assert jnp.all(jnp.isnan(out))
+
+
+    @pytest.mark.parametrize(
+        "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
+    )
+    @pytest.mark.parametrize("T_A", T_A_list)
+    @pytest.mark.parametrize("N", N_list)
+    def test_cusolver_solve_arange_dev_1(N, T_A, dtype):
+        cusolver_solve_arange(N, T_A, dtype)
+
+
+    @pytest.mark.parametrize(
+        "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
+    )
+    @pytest.mark.parametrize("T_A", T_A_list)
+    @pytest.mark.parametrize("N", N_list)
+    def test_cusolver_solve_psd_dev_1(N, T_A, dtype):
+        cusolver_solve_psd(N, T_A, dtype)
+
+
+    @pytest.mark.parametrize(
+        "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
+    )
+    @pytest.mark.parametrize("T_A", T_A_list)
+    @pytest.mark.parametrize("N", N_list)
+    def test_cusolver_solve_non_psd_dev_1(N, T_A, dtype):
+        cusolver_solve_non_psd(N, T_A, dtype)
+
+
+    @pytest.mark.parametrize(
+        "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
+    )
+    @pytest.mark.parametrize("T_A", T_A_list)
+    @pytest.mark.parametrize("N", N_list)
+    def test_cusolver_solve_non_symm_dev_1(N, T_A, dtype):
+        cusolver_solve_non_symm(N, T_A, dtype)
+
+
+    @pytest.mark.parametrize(
+        "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
+    )
+    def test_cusolver_inplace_check(dtype):
+        N = ndev * 2
+        T_A = 1
+        A = random_psd(N, dtype=dtype, seed=1234)
+        expected_out = jnp.linalg.inv(A)
+        # Make mesh and place data
+        _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+        A_inv = jitted_potri(_A, T_A)
+        norm_potri = jnp.linalg.norm(A @ A_inv - jnp.eye(N, dtype=dtype))
+        norm_lax = jnp.linalg.norm(A @ expected_out - jnp.eye(N, dtype=dtype))
+        assert jnp.isclose(norm_potri, norm_lax, rtol=10, atol=1e-8)
+        A_inv = jitted_potri(_A, T_A)
+        norm_potri = jnp.linalg.norm(A @ A_inv - jnp.eye(N, dtype=dtype))
+        assert jnp.isclose(norm_potri, norm_lax, rtol=10, atol=1e-8)
+
+    def test_potri_loop_shm():
+        N = ndev * 2
+        T_A = 1
+        dtype = jnp.float64
+        A = random_psd(N, dtype=dtype, seed=5678)
+        _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+        fd_start = len(os.listdir("/proc/self/fd"))
+        for i in range(100):
+            out = jitted_potri(_A,  T_A)
+            out.block_until_ready()
+        fd_end = len(os.listdir("/proc/self/fd"))
+        assert fd_end - fd_start < 100

--- a/tests/spmd/test_potri.py
+++ b/tests/spmd/test_potri.py
@@ -56,7 +56,6 @@ else:
         A = jnp.diag(jnp.arange(N, dtype=dtype) + 1)
         # Make mesh and place data
         _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-
         out = jitted_potri(_A.copy(), T_A)
         out.block_until_ready()
         expected_out = jnp.diag(1.0 / (jnp.arange(N, dtype=dtype) + 1))

--- a/tests/spmd/test_potri.py
+++ b/tests/spmd/test_potri.py
@@ -58,6 +58,7 @@ else:
         _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
 
         out = jitted_potri(_A.copy(), T_A)
+        out.block_until_ready()
         expected_out = jnp.diag(1.0 / (jnp.arange(N, dtype=dtype) + 1))
         assert jnp.allclose(out, expected_out)
         expected_out_no_shm, _ = jitted_potri_no_shardmap(_A, T_A)
@@ -71,6 +72,7 @@ else:
         # Make mesh and place data
         _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
         out = jitted_potri(_A, T_A)
+        out.block_until_ready()
         assert jnp.allclose(A.conj().T, A)
         norm_potri = jnp.linalg.norm(A @ out - jnp.eye(N, dtype=dtype))
         norm_lax = jnp.linalg.norm(A @ expected_out - jnp.eye(N, dtype=dtype))

--- a/tests/spmd/test_potrs.py
+++ b/tests/spmd/test_potrs.py
@@ -172,7 +172,6 @@ def test_cusolver_inplace_check(dtype):
 
 
 def test_potrs_multiple_rhs():
-    """Test potrs with multiple right-hand sides (b shape (N, 3))."""
     N = ndev * 2
     T_A = 1
     dtype = jnp.float64
@@ -184,3 +183,20 @@ def test_potrs_multiple_rhs():
     _b = jax.device_put(b, NamedSharding(mesh, P(None, None)))
     out = jitted_potrs(_A, _b, T_A)
     assert jnp.allclose(out, expected_out, atol=1e-4)
+
+
+def test_potrs_loop_shm():
+    N = ndev * 2
+    T_A = 1
+    dtype = jnp.float64
+    A = random_psd(N, dtype=dtype, seed=5678)
+    b = jnp.arange(N, dtype=dtype)
+
+    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+    _b = jax.device_put(b, NamedSharding(mesh, P(None)))
+    fd_start = len(os.listdir("/proc/self/fd"))
+    for i in range(100):
+        out = jitted_potrs(_A, _b, T_A)
+        out.block_until_ready()
+    fd_end = len(os.listdir("/proc/self/fd"))
+    assert fd_end - fd_start < 100

--- a/tests/spmd/test_potrs.py
+++ b/tests/spmd/test_potrs.py
@@ -15,9 +15,9 @@ from jaxmg.utils import random_psd
 
 from functools import partial
 
-if len(jax.devices("gpu"))==0:
+if len(jax.devices("gpu")) == 0:
     pytest.skip("No GPUs found. Skipping test...")
-    
+
 devices = [d for d in jax.devices() if d.platform == "gpu"]
 ndev = len(devices)
 mesh = jax.make_mesh((ndev,), ("x",))
@@ -29,16 +29,14 @@ T_A_list = [1, 2, 3, 5]
 
 @partial(jax.jit, static_argnames=("_T_A",))
 def jitted_potrs(_a, _b, _T_A):
-    out = partial(potrs, mesh=mesh, in_specs=(P("x", None),), pad=True)(
-        _a, _b, _T_A
-    )
+    out = partial(potrs, mesh=mesh, in_specs=(P("x", None),), pad=True)(_a, _b, _T_A)
     return out
 
 
 @partial(jax.jit, static_argnames=("_T_A",))
 def jitted_potrs_status(_a, _b, _T_A):
     out = partial(
-        potrs, mesh=mesh, in_specs=(P("x", None), ), pad=True, return_status=True
+        potrs, mesh=mesh, in_specs=(P("x", None),), pad=True, return_status=True
     )(_a, _b, _T_A)
     return out
 
@@ -152,6 +150,7 @@ def test_cusolver_solve_non_psd(N, T_A, dtype):
 def test_cusolver_solve_non_symm(N, T_A, dtype):
     cusolver_solve_non_symm(N, T_A, dtype)
 
+
 @pytest.mark.parametrize(
     "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
 )
@@ -168,5 +167,20 @@ def test_cusolver_inplace_check(dtype):
 
     out = jitted_potrs(_A, _b, T_A)
     assert jnp.allclose(out, expected_out, atol=1e-4)
+    out = jitted_potrs(_A, _b, T_A)
+    assert jnp.allclose(out, expected_out, atol=1e-4)
+
+
+def test_potrs_multiple_rhs():
+    """Test potrs with multiple right-hand sides (b shape (N, 3))."""
+    N = ndev * 2
+    T_A = 1
+    dtype = jnp.float64
+    A = random_psd(N, dtype=dtype, seed=5678)
+    b = jnp.arange(N * 3, dtype=dtype).reshape(N, 3) + 1
+    cfac = jax.scipy.linalg.cho_factor(A)
+    expected_out = jax.scipy.linalg.cho_solve(cfac, b)
+    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+    _b = jax.device_put(b, NamedSharding(mesh, P(None, None)))
     out = jitted_potrs(_A, _b, T_A)
     assert jnp.allclose(out, expected_out, atol=1e-4)

--- a/tests/spmd/test_potrs.py
+++ b/tests/spmd/test_potrs.py
@@ -29,7 +29,7 @@ T_A_list = [1, 2, 3, 5]
 
 @partial(jax.jit, static_argnames=("_T_A",))
 def jitted_potrs(_a, _b, _T_A):
-    out = partial(potrs, mesh=mesh, in_specs=(P("x", None), P(None, None)), pad=True)(
+    out = partial(potrs, mesh=mesh, in_specs=(P("x", None),), pad=True)(
         _a, _b, _T_A
     )
     return out
@@ -38,7 +38,7 @@ def jitted_potrs(_a, _b, _T_A):
 @partial(jax.jit, static_argnames=("_T_A",))
 def jitted_potrs_status(_a, _b, _T_A):
     out = partial(
-        potrs, mesh=mesh, in_specs=(P("x", None), P(None, None)), pad=True, return_status=True
+        potrs, mesh=mesh, in_specs=(P("x", None), ), pad=True, return_status=True
     )(_a, _b, _T_A)
     return out
 
@@ -77,7 +77,7 @@ def cusolver_solve_psd(N, T_A, dtype):
     _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
     _b = jax.device_put(b, NamedSharding(mesh, P(None, None)))
 
-    out = jitted_potrs(_A.copy(), _b.copy(), T_A)
+    out = jitted_potrs(_A.copy(), _b.copy().squeeze(), T_A)
     norm_scipy = jnp.linalg.norm(b - A @ expected_out)
     norm_potrf = jnp.linalg.norm(b - A @ out)
     assert jnp.isclose(norm_scipy, norm_potrf, atol=1e-4)

--- a/tests/spmd/test_potrs.py
+++ b/tests/spmd/test_potrs.py
@@ -60,6 +60,7 @@ else:
         _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
         _b = jax.device_put(b, NamedSharding(mesh, P(None, None)))
         out = jitted_potrs(_A.copy(), _b.copy(), T_A)
+        out.block_until_ready()
         expected_out = 1.0 / (jnp.arange(N, dtype=dtype) + 1)
         assert jnp.allclose(out.flatten(), expected_out)
         out_no_shm, _ = jitted_potrs_no_shardmap(_A.copy(), _b.copy(), T_A)
@@ -76,6 +77,7 @@ else:
         _b = jax.device_put(b, NamedSharding(mesh, P(None, None)))
 
         out = jitted_potrs(_A.copy(), _b.copy().squeeze(), T_A)
+        out.block_until_ready()
         norm_scipy = jnp.linalg.norm(b - A @ expected_out)
         norm_potrf = jnp.linalg.norm(b - A @ out)
         assert jnp.isclose(norm_scipy, norm_potrf, atol=1e-4)

--- a/tests/spmd/test_potrs.py
+++ b/tests/spmd/test_potrs.py
@@ -15,188 +15,188 @@ from jaxmg.utils import random_psd
 
 from functools import partial
 
-if len(jax.devices("gpu")) == 0:
-    pytest.skip("No GPUs found. Skipping test...")
+platforms = set(d.platform for d in jax.devices())
+if "gpu" not in platforms:
+    pytest.skip("No GPUs found. Skipping", allow_module_level=True)
+else:
+    ndev = jax.device_count()
+    mesh = jax.make_mesh((ndev,), ("x",))
 
-devices = [d for d in jax.devices() if d.platform == "gpu"]
-ndev = len(devices)
-mesh = jax.make_mesh((ndev,), ("x",))
-
-# Test cases
-N_list = list(i * ndev for i in [2, 3, 4, 10])
-T_A_list = [1, 2, 3, 5]
-
-
-@partial(jax.jit, static_argnames=("_T_A",))
-def jitted_potrs(_a, _b, _T_A):
-    out = partial(potrs, mesh=mesh, in_specs=(P("x", None),), pad=True)(_a, _b, _T_A)
-    return out
+    # Test cases
+    N_list = list(i * ndev for i in [2, 3, 4, 10])
+    T_A_list = [1, 2, 3, 5]
 
 
-@partial(jax.jit, static_argnames=("_T_A",))
-def jitted_potrs_status(_a, _b, _T_A):
-    out = partial(
-        potrs, mesh=mesh, in_specs=(P("x", None),), pad=True, return_status=True
-    )(_a, _b, _T_A)
-    return out
+    @partial(jax.jit, static_argnames=("_T_A",))
+    def jitted_potrs(_a, _b, _T_A):
+        out = partial(potrs, mesh=mesh, in_specs=(P("x", None),), pad=True)(_a, _b, _T_A)
+        return out
 
 
-@partial(jax.jit, static_argnames=("_T_A",))
-def jitted_potrs_no_shardmap(_a, _b, _T_A):
-    out = jax.shard_map(
-        partial(potrs_shardmap_ctx, T_A=_T_A),
-        mesh=mesh,
-        in_specs=(P("x", None), P(None, None)),
-        out_specs=(P(None, None), P(None)),
-        check_vma=False,
-    )(_a, _b)
-    return out
+    @partial(jax.jit, static_argnames=("_T_A",))
+    def jitted_potrs_status(_a, _b, _T_A):
+        out = partial(
+            potrs, mesh=mesh, in_specs=(P("x", None),), pad=True, return_status=True
+        )(_a, _b, _T_A)
+        return out
 
 
-def cusolver_solve_arange(N, T_A, dtype):
-    A = jnp.diag(jnp.arange(N, dtype=dtype) + 1)
-    b = jnp.ones((N, 1), dtype=dtype)
-    # Make mesh and place data
-    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    _b = jax.device_put(b, NamedSharding(mesh, P(None, None)))
-    out = jitted_potrs(_A.copy(), _b.copy(), T_A)
-    expected_out = 1.0 / (jnp.arange(N, dtype=dtype) + 1)
-    assert jnp.allclose(out.flatten(), expected_out)
-    out_no_shm, _ = jitted_potrs_no_shardmap(_A.copy(), _b.copy(), T_A)
-    assert jnp.allclose(out_no_shm.flatten(), expected_out)
+    @partial(jax.jit, static_argnames=("_T_A",))
+    def jitted_potrs_no_shardmap(_a, _b, _T_A):
+        out = jax.shard_map(
+            partial(potrs_shardmap_ctx, T_A=_T_A),
+            mesh=mesh,
+            in_specs=(P("x", None), P(None, None)),
+            out_specs=(P(None, None), P(None)),
+            check_vma=False,
+        )(_a, _b)
+        return out
 
 
-def cusolver_solve_psd(N, T_A, dtype):
-    A = random_psd(N, dtype=dtype, seed=1234)
-    b = jnp.ones((N, 1), dtype=dtype)
-    cfac = jax.scipy.linalg.cho_factor(A)
-    expected_out = jax.scipy.linalg.cho_solve(cfac, b)
-    # Make mesh and place data
-    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    _b = jax.device_put(b, NamedSharding(mesh, P(None, None)))
-
-    out = jitted_potrs(_A.copy(), _b.copy().squeeze(), T_A)
-    norm_scipy = jnp.linalg.norm(b - A @ expected_out)
-    norm_potrf = jnp.linalg.norm(b - A @ out)
-    assert jnp.isclose(norm_scipy, norm_potrf, atol=1e-4)
-    out_no_shm, _ = jitted_potrs_no_shardmap(_A.copy(), _b.copy(), T_A)
-    norm_scipy = jnp.linalg.norm(b - A @ expected_out)
-    norm_potrf = jnp.linalg.norm(b - A @ out_no_shm)
-    assert jnp.allclose(out_no_shm.flatten(), out.flatten())
+    def cusolver_solve_arange(N, T_A, dtype):
+        A = jnp.diag(jnp.arange(N, dtype=dtype) + 1)
+        b = jnp.ones((N, 1), dtype=dtype)
+        # Make mesh and place data
+        _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+        _b = jax.device_put(b, NamedSharding(mesh, P(None, None)))
+        out = jitted_potrs(_A.copy(), _b.copy(), T_A)
+        expected_out = 1.0 / (jnp.arange(N, dtype=dtype) + 1)
+        assert jnp.allclose(out.flatten(), expected_out)
+        out_no_shm, _ = jitted_potrs_no_shardmap(_A.copy(), _b.copy(), T_A)
+        assert jnp.allclose(out_no_shm.flatten(), expected_out)
 
 
-def cusolver_solve_non_psd(N, T_A, dtype):
-    A = jnp.diag(jnp.arange(N, dtype=dtype) - 1)
-    b = jnp.ones((N, 1), dtype=dtype)
-    # Make mesh and place data
-    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    _b = jax.device_put(b, NamedSharding(mesh, P(None, None)))
+    def cusolver_solve_psd(N, T_A, dtype):
+        A = random_psd(N, dtype=dtype, seed=1234)
+        b = jnp.ones((N, 1), dtype=dtype)
+        cfac = jax.scipy.linalg.cho_factor(A)
+        expected_out = jax.scipy.linalg.cho_solve(cfac, b)
+        # Make mesh and place data
+        _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+        _b = jax.device_put(b, NamedSharding(mesh, P(None, None)))
 
-    out, status = jitted_potrs_status(_A.copy(), _b.copy(), T_A)
-    status.block_until_ready()
-    out.block_until_ready()
-    assert status == 7
-    assert jnp.all(jnp.isnan(out))
-
-
-def cusolver_solve_non_symm(N, T_A, dtype):
-    A = jnp.diag(jnp.arange(N, dtype=dtype) + 1)
-    # TODO: For some reason the solver does not fail when we set this to 1.0.
-    A = A.at[0, 1].set(2.0)
-    b = jnp.ones((N, 1), dtype=dtype)
-    # Make mesh and place data
-    A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    b = jax.device_put(b, NamedSharding(mesh, P(None, None)))
-
-    out, status = jitted_potrs_status(A, b, T_A)
-    status.block_until_ready()
-    out.block_until_ready()
-    assert status == 7
-    assert jnp.all(jnp.isnan(out))
+        out = jitted_potrs(_A.copy(), _b.copy().squeeze(), T_A)
+        norm_scipy = jnp.linalg.norm(b - A @ expected_out)
+        norm_potrf = jnp.linalg.norm(b - A @ out)
+        assert jnp.isclose(norm_scipy, norm_potrf, atol=1e-4)
+        out_no_shm, _ = jitted_potrs_no_shardmap(_A.copy(), _b.copy(), T_A)
+        norm_scipy = jnp.linalg.norm(b - A @ expected_out)
+        norm_potrf = jnp.linalg.norm(b - A @ out_no_shm)
+        assert jnp.allclose(out_no_shm.flatten(), out.flatten())
 
 
-@pytest.mark.parametrize(
-    "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
-)
-@pytest.mark.parametrize("T_A", T_A_list)
-@pytest.mark.parametrize("N", N_list)
-def test_cusolver_solve_arange(N, T_A, dtype):
-    cusolver_solve_arange(N, T_A, dtype)
+    def cusolver_solve_non_psd(N, T_A, dtype):
+        A = jnp.diag(jnp.arange(N, dtype=dtype) - 1)
+        b = jnp.ones((N, 1), dtype=dtype)
+        # Make mesh and place data
+        _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+        _b = jax.device_put(b, NamedSharding(mesh, P(None, None)))
 
-
-@pytest.mark.parametrize(
-    "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
-)
-@pytest.mark.parametrize("T_A", T_A_list)
-@pytest.mark.parametrize("N", N_list)
-def test_cusolver_solve_psd(N, T_A, dtype):
-    cusolver_solve_psd(N, T_A, dtype)
-
-
-@pytest.mark.parametrize(
-    "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
-)
-@pytest.mark.parametrize("T_A", T_A_list)
-@pytest.mark.parametrize("N", N_list)
-def test_cusolver_solve_non_psd(N, T_A, dtype):
-    cusolver_solve_non_psd(N, T_A, dtype)
-
-
-@pytest.mark.parametrize(
-    "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
-)
-@pytest.mark.parametrize("T_A", T_A_list)
-@pytest.mark.parametrize("N", N_list)
-def test_cusolver_solve_non_symm(N, T_A, dtype):
-    cusolver_solve_non_symm(N, T_A, dtype)
-
-
-@pytest.mark.parametrize(
-    "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
-)
-def test_cusolver_inplace_check(dtype):
-    N = ndev * 2
-    T_A = 1
-    A = random_psd(N, dtype=dtype, seed=1234)
-    b = jnp.ones((N, 1), dtype=dtype)
-    cfac = jax.scipy.linalg.cho_factor(A)
-    expected_out = jax.scipy.linalg.cho_solve(cfac, b)
-    # Make mesh and place data
-    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    _b = jax.device_put(b, NamedSharding(mesh, P(None, None)))
-
-    out = jitted_potrs(_A, _b, T_A)
-    assert jnp.allclose(out, expected_out, atol=1e-4)
-    out = jitted_potrs(_A, _b, T_A)
-    assert jnp.allclose(out, expected_out, atol=1e-4)
-
-
-def test_potrs_multiple_rhs():
-    N = ndev * 2
-    T_A = 1
-    dtype = jnp.float64
-    A = random_psd(N, dtype=dtype, seed=5678)
-    b = jnp.arange(N * 3, dtype=dtype).reshape(N, 3) + 1
-    cfac = jax.scipy.linalg.cho_factor(A)
-    expected_out = jax.scipy.linalg.cho_solve(cfac, b)
-    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    _b = jax.device_put(b, NamedSharding(mesh, P(None, None)))
-    out = jitted_potrs(_A, _b, T_A)
-    assert jnp.allclose(out, expected_out, atol=1e-4)
-
-
-def test_potrs_loop_shm():
-    N = ndev * 2
-    T_A = 1
-    dtype = jnp.float64
-    A = random_psd(N, dtype=dtype, seed=5678)
-    b = jnp.arange(N, dtype=dtype)
-
-    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    _b = jax.device_put(b, NamedSharding(mesh, P(None)))
-    fd_start = len(os.listdir("/proc/self/fd"))
-    for i in range(100):
-        out = jitted_potrs(_A, _b, T_A)
+        out, status = jitted_potrs_status(_A.copy(), _b.copy(), T_A)
+        status.block_until_ready()
         out.block_until_ready()
-    fd_end = len(os.listdir("/proc/self/fd"))
-    assert fd_end - fd_start < 100
+        assert status == 7
+        assert jnp.all(jnp.isnan(out))
+
+
+    def cusolver_solve_non_symm(N, T_A, dtype):
+        A = jnp.diag(jnp.arange(N, dtype=dtype) + 1)
+        # TODO: For some reason the solver does not fail when we set this to 1.0.
+        A = A.at[0, 1].set(2.0)
+        b = jnp.ones((N, 1), dtype=dtype)
+        # Make mesh and place data
+        A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+        b = jax.device_put(b, NamedSharding(mesh, P(None, None)))
+
+        out, status = jitted_potrs_status(A, b, T_A)
+        status.block_until_ready()
+        out.block_until_ready()
+        assert status == 7
+        assert jnp.all(jnp.isnan(out))
+
+
+    @pytest.mark.parametrize(
+        "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
+    )
+    @pytest.mark.parametrize("T_A", T_A_list)
+    @pytest.mark.parametrize("N", N_list)
+    def test_cusolver_solve_arange(N, T_A, dtype):
+        cusolver_solve_arange(N, T_A, dtype)
+
+
+    @pytest.mark.parametrize(
+        "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
+    )
+    @pytest.mark.parametrize("T_A", T_A_list)
+    @pytest.mark.parametrize("N", N_list)
+    def test_cusolver_solve_psd(N, T_A, dtype):
+        cusolver_solve_psd(N, T_A, dtype)
+
+
+    @pytest.mark.parametrize(
+        "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
+    )
+    @pytest.mark.parametrize("T_A", T_A_list)
+    @pytest.mark.parametrize("N", N_list)
+    def test_cusolver_solve_non_psd(N, T_A, dtype):
+        cusolver_solve_non_psd(N, T_A, dtype)
+
+
+    @pytest.mark.parametrize(
+        "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
+    )
+    @pytest.mark.parametrize("T_A", T_A_list)
+    @pytest.mark.parametrize("N", N_list)
+    def test_cusolver_solve_non_symm(N, T_A, dtype):
+        cusolver_solve_non_symm(N, T_A, dtype)
+
+
+    @pytest.mark.parametrize(
+        "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
+    )
+    def test_cusolver_inplace_check(dtype):
+        N = ndev * 2
+        T_A = 1
+        A = random_psd(N, dtype=dtype, seed=1234)
+        b = jnp.ones((N, 1), dtype=dtype)
+        cfac = jax.scipy.linalg.cho_factor(A)
+        expected_out = jax.scipy.linalg.cho_solve(cfac, b)
+        # Make mesh and place data
+        _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+        _b = jax.device_put(b, NamedSharding(mesh, P(None, None)))
+
+        out = jitted_potrs(_A, _b, T_A)
+        assert jnp.allclose(out, expected_out, atol=1e-4)
+        out = jitted_potrs(_A, _b, T_A)
+        assert jnp.allclose(out, expected_out, atol=1e-4)
+
+
+    def test_potrs_multiple_rhs():
+        N = ndev * 2
+        T_A = 1
+        dtype = jnp.float64
+        A = random_psd(N, dtype=dtype, seed=5678)
+        b = jnp.arange(N * 3, dtype=dtype).reshape(N, 3) + 1
+        cfac = jax.scipy.linalg.cho_factor(A)
+        expected_out = jax.scipy.linalg.cho_solve(cfac, b)
+        _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+        _b = jax.device_put(b, NamedSharding(mesh, P(None, None)))
+        out = jitted_potrs(_A, _b, T_A)
+        assert jnp.allclose(out, expected_out, atol=1e-4)
+
+
+    def test_potrs_loop_shm():
+        N = ndev * 2
+        T_A = 1
+        dtype = jnp.float64
+        A = random_psd(N, dtype=dtype, seed=5678)
+        b = jnp.arange(N, dtype=dtype)
+
+        _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+        _b = jax.device_put(b, NamedSharding(mesh, P(None)))
+        fd_start = len(os.listdir("/proc/self/fd"))
+        for i in range(100):
+            out = jitted_potrs(_A, _b, T_A)
+            out.block_until_ready()
+        fd_end = len(os.listdir("/proc/self/fd"))
+        assert fd_end - fd_start < 100

--- a/tests/spmd/test_syevd.py
+++ b/tests/spmd/test_syevd.py
@@ -166,3 +166,30 @@ def test_cusolver_inplace_check(dtype):
     assert jnp.allclose(expected, eigenvalues, atol=1e-4)
     eigenvalues, _ = jitted_syevd(_A, T_A)
     assert jnp.allclose(expected, eigenvalues, atol=1e-4)
+
+
+def test_syevd_loop_shm():
+    N = ndev * 2
+    T_A = 1
+    dtype = jnp.float64
+    A = random_psd(N, dtype=dtype, seed=5678)
+    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+    fd_start = len(os.listdir("/proc/self/fd"))
+    for i in range(100):
+        out,_ = jitted_syevd(_A,  T_A)
+        out.block_until_ready()
+    fd_end = len(os.listdir("/proc/self/fd"))
+    assert fd_end - fd_start < 100
+
+def test_syevd_no_V_loop_shm():
+    N = ndev * 2
+    T_A = 1
+    dtype = jnp.float64
+    A = random_psd(N, dtype=dtype, seed=5678)
+    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+    fd_start = len(os.listdir("/proc/self/fd"))
+    for i in range(100):
+        out = jitted_syevd_no_V(_A,  T_A)
+        out.block_until_ready()
+    fd_end = len(os.listdir("/proc/self/fd"))
+    assert fd_end - fd_start < 100

--- a/tests/spmd/test_syevd.py
+++ b/tests/spmd/test_syevd.py
@@ -73,6 +73,8 @@ else:
         # Make mesh and place data
         _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
         eigenvalues, V = jitted_syevd(_A.copy(), T_A)
+        eigenvalues.block_until_ready()
+        V.block_until_ready()
         assert jnp.allclose(eigenvalues_expected, eigenvalues)
         eigenvalus_VtAV = jnp.diag(V @ A @ V.T)
         assert jnp.allclose(eigenvalus_VtAV, eigenvalues_expected)
@@ -86,6 +88,8 @@ else:
         # Make mesh and place data
         _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
         eigenvalues, V = jitted_syevd(_A.copy(), T_A)
+        eigenvalues.block_until_ready()
+        V.block_until_ready()
         norm_syevd = jnp.linalg.norm(V @ A - jnp.diag(eigenvalues) @ V.T)
         norm_lax = jnp.linalg.norm(
             V_expected @ A - jnp.diag(eigenvalues_expected) @ V_expected.T
@@ -101,6 +105,7 @@ else:
         # Make mesh and place data
         _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
         eigenvalues = jitted_syevd_no_V(_A.copy(), T_A)
+        eigenvalues.block_until_ready()
         assert jnp.allclose(eigenvalues_expected, eigenvalues)
         eigenvalues_no_shm, _ = jitted_syevd_no_V_no_shardmap(_A.copy(), T_A)
         assert jnp.allclose(eigenvalues_expected, eigenvalues_no_shm)
@@ -112,6 +117,7 @@ else:
         # Make mesh and place data
         _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
         eigenvalues = jitted_syevd_no_V(A.copy(), T_A)
+        eigenvalues.block_until_ready()
         assert jnp.allclose(eigenvalues, eigenvalues_expected, rtol=10, atol=0.0)
         eigenvalues_no_shm, _ = jitted_syevd_no_V_no_shardmap(_A.copy(), T_A)
         assert jnp.allclose(eigenvalues_expected, eigenvalues_no_shm, rtol=10, atol=0.0)

--- a/tests/spmd/test_syevd.py
+++ b/tests/spmd/test_syevd.py
@@ -17,179 +17,179 @@ from functools import partial
 from jaxmg import syevd, syevd_shardmap_ctx
 from jaxmg.utils import random_psd
 
-if len(jax.devices("gpu"))==0:
-    pytest.skip("No GPUs found. Skipping test...")
-    
-devices = [d for d in jax.devices() if d.platform == "gpu"]
-ndev = len(devices)
-mesh = jax.make_mesh((ndev,), ("x",))
+platforms = set(d.platform for d in jax.devices())
+if "gpu" not in platforms:
+    pytest.skip("No GPUs found. Skipping", allow_module_level=True)
+else:
+    ndev = jax.device_count()
+    mesh = jax.make_mesh((ndev,), ("x",))
 
-# Test cases
-N_list = list(i * ndev for i in [2, 3, 4, 10])
-T_A_list = [1, 2, 3, 5]
-
-
-@partial(jax.jit, static_argnames=("_T_A",))
-def jitted_syevd(_a, _T_A):
-    out = partial(syevd, mesh=mesh, in_specs=(P("x", None),), pad=True)(_a, _T_A)
-    return out
+    # Test cases
+    N_list = list(i * ndev for i in [2, 3, 4, 10])
+    T_A_list = [1, 2, 3, 5]
 
 
-@partial(jax.jit, static_argnames=("_T_A",))
-def jitted_syevd_no_shardmap(_a, _T_A):
-    out = jax.shard_map(
-        partial(syevd_shardmap_ctx, T_A=_T_A),
-        mesh=mesh,
-        in_specs=(P("x", None),),
-        out_specs=(P(None), P(None, None), P(None)),
-        check_vma=False,
-    )(_a)
-    return out
+    @partial(jax.jit, static_argnames=("_T_A",))
+    def jitted_syevd(_a, _T_A):
+        out = partial(syevd, mesh=mesh, in_specs=(P("x", None),), pad=True)(_a, _T_A)
+        return out
 
 
-@partial(jax.jit, static_argnames=("_T_A",))
-def jitted_syevd_no_V(_a, _T_A):
-    out = partial(
-        syevd, mesh=mesh, in_specs=(P("x", None),), return_eigenvectors=False, pad=True
-    )(_a, _T_A)
-    return out
+    @partial(jax.jit, static_argnames=("_T_A",))
+    def jitted_syevd_no_shardmap(_a, _T_A):
+        out = jax.shard_map(
+            partial(syevd_shardmap_ctx, T_A=_T_A),
+            mesh=mesh,
+            in_specs=(P("x", None),),
+            out_specs=(P(None), P(None, None), P(None)),
+            check_vma=False,
+        )(_a)
+        return out
 
 
-@partial(jax.jit, static_argnames=("_T_A",))
-def jitted_syevd_no_V_no_shardmap(_a, _T_A):
-    out = jax.shard_map(
-        partial(syevd_shardmap_ctx, T_A=_T_A, return_eigenvectors=False),
-        mesh=mesh,
-        in_specs=(P("x", None),),
-        out_specs=(P(None), P(None)),
-        check_vma=False,
-    )(_a)
-    return out
+    @partial(jax.jit, static_argnames=("_T_A",))
+    def jitted_syevd_no_V(_a, _T_A):
+        out = partial(
+            syevd, mesh=mesh, in_specs=(P("x", None),), return_eigenvectors=False, pad=True
+        )(_a, _T_A)
+        return out
 
 
-def cusolver_solve_arange(N, T_A, dtype):
-    A = jnp.diag(jnp.arange(N, dtype=dtype) + 1)
-    eigenvalues_expected = jnp.diag(A)
-    # Make mesh and place data
-    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    eigenvalues, V = jitted_syevd(_A.copy(), T_A)
-    assert jnp.allclose(eigenvalues_expected, eigenvalues)
-    eigenvalus_VtAV = jnp.diag(V @ A @ V.T)
-    assert jnp.allclose(eigenvalus_VtAV, eigenvalues_expected)
-    eigenvalues_no_shm, V, _ = jitted_syevd_no_shardmap(_A.copy(), T_A)
-    assert jnp.allclose(eigenvalues_expected, eigenvalues_no_shm)
+    @partial(jax.jit, static_argnames=("_T_A",))
+    def jitted_syevd_no_V_no_shardmap(_a, _T_A):
+        out = jax.shard_map(
+            partial(syevd_shardmap_ctx, T_A=_T_A, return_eigenvectors=False),
+            mesh=mesh,
+            in_specs=(P("x", None),),
+            out_specs=(P(None), P(None)),
+            check_vma=False,
+        )(_a)
+        return out
 
 
-def cusolver_solve_psd(N, T_A, dtype):
-    A = random_psd(N, dtype=dtype, seed=1234)
-    eigenvalues_expected, V_expected = jnp.linalg.eigh(A)
-    # Make mesh and place data
-    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    eigenvalues, V = jitted_syevd(_A.copy(), T_A)
-    norm_syevd = jnp.linalg.norm(V @ A - jnp.diag(eigenvalues) @ V.T)
-    norm_lax = jnp.linalg.norm(
-        V_expected @ A - jnp.diag(eigenvalues_expected) @ V_expected.T
+    def cusolver_solve_arange(N, T_A, dtype):
+        A = jnp.diag(jnp.arange(N, dtype=dtype) + 1)
+        eigenvalues_expected = jnp.diag(A)
+        # Make mesh and place data
+        _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+        eigenvalues, V = jitted_syevd(_A.copy(), T_A)
+        assert jnp.allclose(eigenvalues_expected, eigenvalues)
+        eigenvalus_VtAV = jnp.diag(V @ A @ V.T)
+        assert jnp.allclose(eigenvalus_VtAV, eigenvalues_expected)
+        eigenvalues_no_shm, V, _ = jitted_syevd_no_shardmap(_A.copy(), T_A)
+        assert jnp.allclose(eigenvalues_expected, eigenvalues_no_shm)
+
+
+    def cusolver_solve_psd(N, T_A, dtype):
+        A = random_psd(N, dtype=dtype, seed=1234)
+        eigenvalues_expected, V_expected = jnp.linalg.eigh(A)
+        # Make mesh and place data
+        _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+        eigenvalues, V = jitted_syevd(_A.copy(), T_A)
+        norm_syevd = jnp.linalg.norm(V @ A - jnp.diag(eigenvalues) @ V.T)
+        norm_lax = jnp.linalg.norm(
+            V_expected @ A - jnp.diag(eigenvalues_expected) @ V_expected.T
+        )
+        assert jnp.isclose(norm_syevd, norm_lax, rtol=10, atol=1e-8)
+        eigenvalues_no_shm, V, _ = jitted_syevd_no_shardmap(_A.copy(), T_A)
+        assert jnp.allclose(eigenvalues_expected, eigenvalues_no_shm, rtol=10, atol=1e-10)
+
+
+    def cusolver_solve_arange_no_V(N, T_A, dtype):
+        A = jnp.diag(jnp.arange(N, dtype=dtype) + 1)
+        eigenvalues_expected = jnp.diag(A)
+        # Make mesh and place data
+        _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+        eigenvalues = jitted_syevd_no_V(_A.copy(), T_A)
+        assert jnp.allclose(eigenvalues_expected, eigenvalues)
+        eigenvalues_no_shm, _ = jitted_syevd_no_V_no_shardmap(_A.copy(), T_A)
+        assert jnp.allclose(eigenvalues_expected, eigenvalues_no_shm)
+
+
+    def cusolver_solve_psd_no_V(N, T_A, dtype):
+        A = random_psd(N, dtype=dtype, seed=1234)
+        eigenvalues_expected = jnp.linalg.eigvalsh(A)
+        # Make mesh and place data
+        _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+        eigenvalues = jitted_syevd_no_V(A.copy(), T_A)
+        assert jnp.allclose(eigenvalues, eigenvalues_expected, rtol=10, atol=0.0)
+        eigenvalues_no_shm, _ = jitted_syevd_no_V_no_shardmap(_A.copy(), T_A)
+        assert jnp.allclose(eigenvalues_expected, eigenvalues_no_shm, rtol=10, atol=0.0)
+
+
+    @pytest.mark.parametrize(
+        "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
     )
-    assert jnp.isclose(norm_syevd, norm_lax, rtol=10, atol=1e-8)
-    eigenvalues_no_shm, V, _ = jitted_syevd_no_shardmap(_A.copy(), T_A)
-    assert jnp.allclose(eigenvalues_expected, eigenvalues_no_shm, rtol=10, atol=1e-10)
+    @pytest.mark.parametrize("T_A", T_A_list)
+    @pytest.mark.parametrize("N", N_list)
+    def test_cusolver_solve_arange(N, T_A, dtype):
+        cusolver_solve_arange(N, T_A, dtype)
 
 
-def cusolver_solve_arange_no_V(N, T_A, dtype):
-    A = jnp.diag(jnp.arange(N, dtype=dtype) + 1)
-    eigenvalues_expected = jnp.diag(A)
-    # Make mesh and place data
-    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    eigenvalues = jitted_syevd_no_V(_A.copy(), T_A)
-    assert jnp.allclose(eigenvalues_expected, eigenvalues)
-    eigenvalues_no_shm, _ = jitted_syevd_no_V_no_shardmap(_A.copy(), T_A)
-    assert jnp.allclose(eigenvalues_expected, eigenvalues_no_shm)
+    @pytest.mark.parametrize(
+        "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
+    )
+    @pytest.mark.parametrize("T_A", T_A_list)
+    @pytest.mark.parametrize("N", N_list)
+    def test_cusolver_solve_psd(N, T_A, dtype):
+        cusolver_solve_psd(N, T_A, dtype)
 
 
-def cusolver_solve_psd_no_V(N, T_A, dtype):
-    A = random_psd(N, dtype=dtype, seed=1234)
-    eigenvalues_expected = jnp.linalg.eigvalsh(A)
-    # Make mesh and place data
-    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    eigenvalues = jitted_syevd_no_V(A.copy(), T_A)
-    assert jnp.allclose(eigenvalues, eigenvalues_expected, rtol=10, atol=0.0)
-    eigenvalues_no_shm, _ = jitted_syevd_no_V_no_shardmap(_A.copy(), T_A)
-    assert jnp.allclose(eigenvalues_expected, eigenvalues_no_shm, rtol=10, atol=0.0)
+    @pytest.mark.parametrize(
+        "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
+    )
+    @pytest.mark.parametrize("T_A", T_A_list)
+    @pytest.mark.parametrize("N", N_list)
+    def test_cusolver_solve_arange_no_v(N, T_A, dtype):
+        cusolver_solve_arange_no_V(N, T_A, dtype)
 
 
-@pytest.mark.parametrize(
-    "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
-)
-@pytest.mark.parametrize("T_A", T_A_list)
-@pytest.mark.parametrize("N", N_list)
-def test_cusolver_solve_arange(N, T_A, dtype):
-    cusolver_solve_arange(N, T_A, dtype)
+    @pytest.mark.parametrize(
+        "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
+    )
+    @pytest.mark.parametrize("T_A", T_A_list)
+    @pytest.mark.parametrize("N", N_list)
+    def test_cusolver_solve_psd_no_v(N, T_A, dtype):
+        cusolver_solve_psd_no_V(N, T_A, dtype)
+
+    @pytest.mark.parametrize(
+        "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
+    )
+    def test_cusolver_inplace_check(dtype):
+        N = ndev * 2
+        T_A = 1
+        A = random_psd(N, dtype=dtype, seed=1234)
+        # Make mesh and place data
+        _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+        expected = jnp.linalg.eigvalsh(A)
+        eigenvalues, _ = jitted_syevd(_A, T_A)
+        assert jnp.allclose(expected, eigenvalues, atol=1e-4)
+        eigenvalues, _ = jitted_syevd(_A, T_A)
+        assert jnp.allclose(expected, eigenvalues, atol=1e-4)
 
 
-@pytest.mark.parametrize(
-    "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
-)
-@pytest.mark.parametrize("T_A", T_A_list)
-@pytest.mark.parametrize("N", N_list)
-def test_cusolver_solve_psd(N, T_A, dtype):
-    cusolver_solve_psd(N, T_A, dtype)
+    def test_syevd_loop_shm():
+        N = ndev * 2
+        T_A = 1
+        dtype = jnp.float64
+        A = random_psd(N, dtype=dtype, seed=5678)
+        _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+        fd_start = len(os.listdir("/proc/self/fd"))
+        for i in range(100):
+            out,_ = jitted_syevd(_A,  T_A)
+            out.block_until_ready()
+        fd_end = len(os.listdir("/proc/self/fd"))
+        assert fd_end - fd_start < 100
 
-
-@pytest.mark.parametrize(
-    "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
-)
-@pytest.mark.parametrize("T_A", T_A_list)
-@pytest.mark.parametrize("N", N_list)
-def test_cusolver_solve_arange_no_v(N, T_A, dtype):
-    cusolver_solve_arange_no_V(N, T_A, dtype)
-
-
-@pytest.mark.parametrize(
-    "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
-)
-@pytest.mark.parametrize("T_A", T_A_list)
-@pytest.mark.parametrize("N", N_list)
-def test_cusolver_solve_psd_no_v(N, T_A, dtype):
-    cusolver_solve_psd_no_V(N, T_A, dtype)
-
-@pytest.mark.parametrize(
-    "dtype", (jnp.float32, jnp.float64, jnp.complex64, jnp.complex128)
-)
-def test_cusolver_inplace_check(dtype):
-    N = ndev * 2
-    T_A = 1
-    A = random_psd(N, dtype=dtype, seed=1234)
-    # Make mesh and place data
-    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    expected = jnp.linalg.eigvalsh(A)
-    eigenvalues, _ = jitted_syevd(_A, T_A)
-    assert jnp.allclose(expected, eigenvalues, atol=1e-4)
-    eigenvalues, _ = jitted_syevd(_A, T_A)
-    assert jnp.allclose(expected, eigenvalues, atol=1e-4)
-
-
-def test_syevd_loop_shm():
-    N = ndev * 2
-    T_A = 1
-    dtype = jnp.float64
-    A = random_psd(N, dtype=dtype, seed=5678)
-    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    fd_start = len(os.listdir("/proc/self/fd"))
-    for i in range(100):
-        out,_ = jitted_syevd(_A,  T_A)
-        out.block_until_ready()
-    fd_end = len(os.listdir("/proc/self/fd"))
-    assert fd_end - fd_start < 100
-
-def test_syevd_no_V_loop_shm():
-    N = ndev * 2
-    T_A = 1
-    dtype = jnp.float64
-    A = random_psd(N, dtype=dtype, seed=5678)
-    _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
-    fd_start = len(os.listdir("/proc/self/fd"))
-    for i in range(100):
-        out = jitted_syevd_no_V(_A,  T_A)
-        out.block_until_ready()
-    fd_end = len(os.listdir("/proc/self/fd"))
-    assert fd_end - fd_start < 100
+    def test_syevd_no_V_loop_shm():
+        N = ndev * 2
+        T_A = 1
+        dtype = jnp.float64
+        A = random_psd(N, dtype=dtype, seed=5678)
+        _A = jax.device_put(A, NamedSharding(mesh, P("x", None)))
+        fd_start = len(os.listdir("/proc/self/fd"))
+        for i in range(100):
+            out = jitted_syevd_no_V(_A,  T_A)
+            out.block_until_ready()
+        fd_end = len(os.listdir("/proc/self/fd"))
+        assert fd_end - fd_start < 100


### PR DESCRIPTION
This PR fixes two issues:

- Shared memory cleanup was not handled correctly, which caused open file descriptors to leak on successive calls to the solvers (see #13).  This is now tested for with tests `test_<SOLVER>_loop_shm` for both SPMD and MPMD.
- In addition, the inputs for potrs'; `b` are no longer required to be 2D, and we do not need to pass the Sharding spec for it any more.

