### PR TITLE
Jenkins: only build monthly on main; pre-build images

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -1,14 +1,21 @@
-properties([
+def props = [
   disableConcurrentBuilds(),
   buildDiscarder(logRotator(numToKeepStr: '8', daysToKeepStr: '30')),
-  pipelineTriggers([cron('@monthly')])
-])
+]
+
+if (env.BRANCH_NAME == "main")
+  props <<= pipelineTriggers([cron('@monthly')])
+
+properties(props)
 
 timeout(time: 2, unit: 'HOURS') {
+  buildImages([
+    [tag: '12', context: '.jenkins', dockerfile: 'Dockerfile12'],
+    [tag: '13', context: '.jenkins', dockerfile: 'Dockerfile13']
+  ], checkout: true)
+
   parallel cuda12: {
-    buildPod(tag: '12',
-      context: '.jenkins',
-      dockerfile: 'Dockerfile12') {
+    runPod(tag: '12') {
           stage('Compile CUDA 12') {
                     withEnv([
                         "CUDA_ROOT=/usr/local/cuda",
@@ -115,9 +122,7 @@ timeout(time: 2, unit: 'HOURS') {
         }
     }
   }, cuda13: {
-    buildPod(tag: '13',
-      context: '.jenkins',
-      dockerfile: 'Dockerfile13') {
+    runPod(tag: '13') {
           stage('Compile CUDA 13') {
                     withEnv([
                         "CUDA_ROOT=/usr/local/cuda",


### PR DESCRIPTION
Disable monthly builds on other branches.

Minor (unrelated) optimization to avoid a checkout.