### PR TITLE
cuSOLVERMp 0.9 and eigenvalues-only SYEVD

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -52,10 +52,10 @@ jobs:
         include:
           - cuda_major: '12'
             cuda_archs: sm_70,sm_80,sm_90,sm_120,compute_90
-            cusolvermp: nvidia-cusolvermp-cu12==0.8.0.3126
+            cusolvermp: nvidia-cusolvermp-cu12==0.9.0.6427
           - cuda_major: '13'
             cuda_archs: sm_80,sm_90,sm_120,compute_90
-            cusolvermp: nvidia-cusolvermp-cu13==0.8.0.3126
+            cusolvermp: nvidia-cusolvermp-cu13==0.9.0.6427
     steps:
       - name: Checkout jaxmg
         uses: actions/checkout@v4
@@ -195,6 +195,7 @@ jobs:
             --exclude 'libcusolver.so*' \
             --exclude 'libcusolverMg.so*' \
             --exclude 'libcusolverMp.so*' \
+            --exclude 'libcublasmp.so*' \
             --exclude 'libcupti.so*' \
             --exclude 'libcusparse.so*' \
             --exclude 'libcublasLt.so*' \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,11 +19,6 @@ A typical contribution follows five steps:
 1. Some native failures still use `std::runtime_error`. Contributions that
    express these consistently through XLA FFI error handling are particularly
    useful.
-2. Support for computing eigenvalues without eigenvectors would also be a useful
-   addition. Initial development with earlier cuSOLVERMp releases encountered
-   issues with the eigenvalues-only mode. The cuSOLVERMp 0.9 interface documents
-   this as `jobz='N'`, but it still requires separate implementation and
-   validation in JAXMg.
 
 ## Pull a clean copy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,10 @@ A typical contribution follows five steps:
    express these consistently through XLA FFI error handling are particularly
    useful.
 2. Support for computing eigenvalues without eigenvectors would also be a useful
-   addition. Initial development encountered issues with cuSOLVERMp's documented
-   eigenvalues-only `compz='N'` mode. This requires further investigation and may
-   need discussion with the cuSOLVERMp developers.
+   addition. Initial development with earlier cuSOLVERMp releases encountered
+   issues with the eigenvalues-only mode. The cuSOLVERMp 0.9 interface documents
+   this as `jobz='N'`, but it still requires separate implementation and
+   validation in JAXMg.
 
 ## Pull a clean copy
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ JAXMg currently provides a jittable API for the following routines:
 - [`lu_solve`](https://flatironinstitute.github.io/jaxmg/api/lu_solve/): Solves the system of linear equations
   $Ax=B$, where $A$ is an $N \times N$ general nonsingular matrix, using a
   pivoted LU decomposition.
-- [`syevd`](https://flatironinstitute.github.io/jaxmg/api/syevd/): Computes the eigenvalues and eigenvectors of an
-  $N \times N$ symmetric or Hermitian matrix.
+- [`syevd`](https://flatironinstitute.github.io/jaxmg/api/syevd/): Computes the
+  eigenvalues and optional eigenvectors of an $N \times N$ symmetric or
+  Hermitian matrix.
 
 ## How JAXMg works
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -50,7 +50,7 @@ $$
 A v = \lambda v \quad\Rightarrow\quad A = V \Lambda V^{\top} \;\text{(real)}\quad\text{or}\quad A = V \Lambda V^{\dagger} \;\text{(complex)}
 $$
 
-Compute eigenvalues $\Lambda$ and eigenvectors $V$ of a symmetric or Hermitian
-matrix.
+Compute eigenvalues $\Lambda$ and optionally eigenvectors $V$ of a symmetric or
+Hermitian matrix.
 
 [`syevd` API and usage](syevd.md)

--- a/docs/api/syevd.md
+++ b/docs/api/syevd.md
@@ -1,23 +1,20 @@
 # jaxmg.syevd
 
-`syevd` computes both eigenvalues and eigenvectors. The input matrix is
-symmetric for real dtypes and Hermitian for complex dtypes. Eigenvalues are
-real, while eigenvectors use the input dtype and are returned in the original
-JAX-facing matrix layout.
+`syevd` computes the eigenvalues and, by default, eigenvectors of a symmetric
+real matrix or Hermitian complex matrix. Eigenvalues are real, while
+eigenvectors use the input dtype and are returned in the original JAX-facing
+matrix layout.
 
-SYEVD materializes a distributed eigenvector matrix and requests
-solver-specific cuSOLVERMp workspace. Its peak memory requirement can therefore
-be substantially larger than a linear solve at the same matrix size.
-
-The eigenvalues are returned as a real array. The eigenvectors use the input
-dtype and are returned with the same JAX-facing matrix layout as `a`.
+Set `return_eigenvectors=False` when only the spectrum is required. This selects
+the eigenvalues-only mode and reduces memory use by avoiding the full
+distributed eigenvector matrix.
 
 Use `syevd` for a direct eigensolve. Use `syevd_shardmap_ctx` when the
 eigensolve is part of a larger caller-owned `jax.jit`. The context interface
 returns the native input-matrix work buffer so the outer compiled function can
 preserve the donated input alias. cuSOLVERMp stores the overwritten input
 matrix and eigenvectors in separate distributed buffers, so `a_work` is the
-alias target rather than the eigenvector output.
+alias target rather than the eigenvector output when vectors are requested.
 
 ::: jaxmg.syevd
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -26,4 +26,4 @@ reduce memory use.
 - [LU solve](lu_solve.md) solves a general nonsingular linear system with
   `lu_solve`.
 - [Symmetric or Hermitian eigensolve](syevd.md) computes eigenvalues and
-  eigenvectors with `syevd`.
+  optional eigenvectors with `syevd`.

--- a/docs/examples/syevd.md
+++ b/docs/examples/syevd.md
@@ -1,9 +1,10 @@
 # Symmetric or Hermitian eigensolve
 
-`jaxmg.syevd` computes the eigenvalues and eigenvectors of a symmetric real
-matrix or Hermitian complex matrix. For a normal eigensolve, use `syevd`. It
-provides the high-level interface and internally handles JIT compilation,
-buffer donation, input/output aliasing, padding, and distributed execution.
+`jaxmg.syevd` computes the eigenvalues and, optionally, eigenvectors of a
+symmetric real matrix or Hermitian complex matrix. For a normal eigensolve, use
+`syevd`. It provides the high-level interface and internally handles JIT
+compilation, buffer donation, input/output aliasing, padding, and distributed
+execution.
 
 ## Common setup
 
@@ -63,6 +64,24 @@ if jax.process_index() == 0:
 The eigenvalues are returned as a real array. The eigenvectors have the input
 dtype and are returned in the same JAX-facing matrix layout as `a`.
 
+When eigenvectors are not required, select the shorter values-only workflow:
+
+```python
+a, expected_eigenvalues = make_problem()
+
+eigenvalues = syevd(
+    a,
+    T_A=T_A,
+    mesh=mesh,
+    matrix_specs=matrix_specs,
+    return_eigenvectors=False,
+)
+eigenvalues.block_until_ready()
+```
+
+This mode does not allocate, reverse-redistribute, or restore a matrix-sized
+eigenvector result.
+
 !!! Warning
 
      The public wrapper donates `a` to the compiled eigensolve. Do not use the
@@ -73,16 +92,16 @@ an internally cached jitted wrapper and manages donation and aliasing itself.
 If the eigensolve must be embedded inside a larger jitted calculation, use the
 advanced interface below instead of wrapping `syevd` in another `jax.jit`.
 
-SYEVD materializes the full distributed eigenvector matrix and uses
-solver-specific workspace. It therefore reaches the GPU memory limit at a
-smaller matrix size than `potrs` or `lu_solve` on the same process grid.
+When eigenvectors are requested, SYEVD materializes the full distributed
+eigenvector matrix and uses solver-specific workspace. It therefore reaches
+the GPU memory limit at a smaller matrix size than `potrs` or `lu_solve` on the
+same process grid.
 
 ## Advanced: control the outer `jax.jit`
 
-`syevd_shardmap_ctx` runs the same padding, redistribution, eigensolve, and
-reverse redistribution as `syevd`. The difference is that it does not create
-an internal `jax.jit`, allowing the eigensolve to become one stage of a larger
-function compiled by the caller.
+`syevd_shardmap_ctx` runs the same selected eigensolver workflow as `syevd`.
+The difference is that it does not create an internal `jax.jit`, allowing the
+eigensolve to become one stage of a larger function compiled by the caller.
 
 The context interface returns
 `(a_work, eigenvalues, eigenvectors, status)`. cuSOLVERMp uses separate
@@ -90,6 +109,9 @@ distributed buffers for its overwritten input matrix and eigenvector output,
 so `a_work` is returned to give the outer compiled function an $A$-sized alias
 target for the donated input. The eigenvectors still require a separate
 matrix-sized allocation.
+
+With `return_eigenvectors=False`, the context interface instead returns
+`(a_work, eigenvalues, status)`.
 
 The advanced examples additionally use:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,8 +18,8 @@ JAXMg currently provides a jittable API for the following routines:
 - [`lu_solve`](api/lu_solve.md): Solves the system of linear equations $Ax=B$,
   where $A$ is an $N \times N$ general nonsingular matrix, using a pivoted LU
   decomposition.
-- [`syevd`](api/syevd.md): Computes the eigenvalues and eigenvectors of an
-  $N \times N$ symmetric or Hermitian matrix.
+- [`syevd`](api/syevd.md): Computes the eigenvalues and optional eigenvectors of
+  an $N \times N$ symmetric or Hermitian matrix.
 
 ## How JAXMg works
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -24,7 +24,7 @@ NVIDIA GPU families are:
 | CUDA 12 | V100, A100, H100/H200, and Blackwell GPUs |
 | CUDA 13 | A100, H100/H200, and Blackwell GPUs |
 
-The binaries use JAX `0.10.1` and cuSOLVERMp `0.8.0.3126`. See
+The binaries use JAX `0.10.1` and cuSOLVERMp `0.9.0.6427`. See
 [Building from source](technical_details/building_from_source.md) for the native
 build procedure.
 

--- a/docs/technical_details/building_from_source.md
+++ b/docs/technical_details/building_from_source.md
@@ -101,7 +101,7 @@ Choose the values for the backend:
 
 ```bash
 CUDA_MAJOR=12
-CUSOLVERMP_PACKAGE=nvidia-cusolvermp-cu12==0.8.0.3126
+CUSOLVERMP_PACKAGE=nvidia-cusolvermp-cu12==0.9.0.6427
 CAPABILITIES=sm_70,sm_80,sm_90,sm_120,compute_90
 ```
 
@@ -126,7 +126,7 @@ For CUDA 13, use:
 
 ```bash
 CUDA_MAJOR=13
-CUSOLVERMP_PACKAGE=nvidia-cusolvermp-cu13==0.8.0.3126
+CUSOLVERMP_PACKAGE=nvidia-cusolvermp-cu13==0.9.0.6427
 CAPABILITIES=sm_80,sm_90,sm_120,compute_90
 ```
 

--- a/docs/technical_details/index.md
+++ b/docs/technical_details/index.md
@@ -30,6 +30,10 @@ redistribution. Matrix data remains GPU-resident throughout this workflow, and
 the in-place transformations reuse bounded native scratch storage to minimize
 memory overhead.
 
+Matrix-valued solver outputs follow the reverse path shown above. The
+eigenvalues-only SYEVD mode returns the replicated eigenvalue array directly
+after solver execution.
+
 ## Scratch allocation
 
 The redistribution path uses one native scratch allocation per FFI call. Its
@@ -90,8 +94,8 @@ The redistribution stages are shared by all public routines:
   all-reduce to return `log(det(A))`.
 - `lu_solve` calls `cusolverMpGetrf` followed by `cusolverMpGetrs` and manages
   the distributed pivot allocation.
-- `syevd` calls `cusolverMpSyevd` and materializes distributed eigenvalues and
-  eigenvectors.
+- `syevd` calls `cusolverMpSyevd` and materializes distributed eigenvalues plus
+  eigenvectors when requested.
 
 Each Python process owns one GPU and contributes one rank to the XLA/NCCL and
 cuSOLVERMp communicators. See [Distributed execution](../examples/execution.md)

--- a/docs/technical_details/memory_distribution.md
+++ b/docs/technical_details/memory_distribution.md
@@ -38,6 +38,9 @@ reverse Stage 3 -> reverse Stage 2 -> reverse Stage 1
 JAX-facing row-major result
 ```
 
+The reverse stages apply to matrix-valued solver outputs. Eigenvalues-only
+SYEVD returns its replicated eigenvalue array directly after solver execution.
+
 The native path is designed around a single scratch allocation.  The scratch
 size is set by Stage 3, the 2D block-cyclic redistribution:
 
@@ -927,8 +930,8 @@ groups inside that wave can run together.
 ## Reverse path
 
 The native solver outputs data in cuSOLVERMp's local column-major block-cyclic
-layout.  The fused call reverses the memory movement stages before returning to
-JAX:
+layout. For matrix-valued outputs, the fused call reverses the memory movement
+stages before returning to JAX:
 
 ```text
 cuSOLVERMp block-cyclic output
@@ -968,8 +971,10 @@ requested by that sequence:
 - `lu_solve` uses `cusolverMpGetrf` followed by `cusolverMpGetrs`.  It is
   intended for general nonsingular matrices and allocates a pivot vector sized
   by the local cuSOLVERMp column ownership, `LOCc(N_A)`.
-- `syevd` uses `cusolverMpSyevd` and has different output and workspace
-  pressure because eigenvectors are materialized as a full distributed matrix.
+- `syevd` uses `cusolverMpSyevd`. Its vector-producing mode has additional
+  output and workspace pressure because eigenvectors are materialized as a
+  full distributed matrix; the eigenvalues-only mode omits that matrix and its
+  reverse redistribution.
 
 ## Python and native responsibilities
 
@@ -987,7 +992,7 @@ Native CUDA/C++ is responsible for:
 - top-left / edge-padding alignment;
 - 2D block-cyclic redistribution;
 - cuSOLVERMp handle, descriptor, workspace, and solver calls;
-- reverse redistribution and layout conversion.
+- reverse redistribution and layout conversion for matrix-valued outputs.
 
 ## Code map
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ docs = [
 dev = [
     "matplotlib>=3.10.3",
     "jax[cuda12]==0.10.1",
-    "nvidia-cusolvermp-cu12==0.8.0.3126",
+    "nvidia-cusolvermp-cu12==0.9.0.6427",
     "pytest==8.2.1",
     "mkdocs==1.6.1",
     "mkdocs-material==9.6.23",
@@ -70,20 +70,20 @@ dev = [
 
 cuda12 = [
     "jax[cuda12]==0.10.1",
-    "nvidia-cusolvermp-cu12==0.8.0.3126",
+    "nvidia-cusolvermp-cu12==0.9.0.6427",
 ]
 
 cuda13 = [
     "jax[cuda13]==0.10.1",
-    "nvidia-cusolvermp-cu13==0.8.0.3126",
+    "nvidia-cusolvermp-cu13==0.9.0.6427",
 ]
 
 cuda12-local = [
     "jax[cuda12-local]==0.10.1",
-    "nvidia-cusolvermp-cu12==0.8.0.3126",
+    "nvidia-cusolvermp-cu12==0.9.0.6427",
 ]
 
 cuda13-local = [
     "jax[cuda13-local]==0.10.1",
-    "nvidia-cusolvermp-cu13==0.8.0.3126",
+    "nvidia-cusolvermp-cu13==0.9.0.6427",
 ]

--- a/src/cuda/cusolvermp_routines/cusolvermp_routines.h
+++ b/src/cuda/cusolvermp_routines/cusolvermp_routines.h
@@ -98,6 +98,19 @@ absl::Status XlaCusolverMpSyevdDispatch(
     const CollectiveParams* collective_params,
     const CollectiveCliques* collective_cliques);
 
+// Runtime eigenvalues-only SYEVD hook. It shares the forward redistribution
+// and cuSOLVERMp setup with vector-producing SYEVD, but omits the eigenvector
+// output and its reverse redistribution.
+absl::Status XlaCusolverMpSyevdValuesDispatch(
+    se::Stream* stream, se::Stream* comm_stream, cudaStream_t cuda_stream,
+    int64_t process_rows, int64_t process_cols, int64_t n, int64_t tile_size,
+    int64_t grid_mapping, absl::Span<const int64_t> rank_map, ffi::AnyBuffer a,
+    ffi::Result<ffi::AnyBuffer> eigenvalues,
+    ffi::Result<ffi::AnyBuffer> work,
+    ffi::Result<ffi::BufferR1<S32>> status,
+    const CollectiveParams* collective_params,
+    const CollectiveCliques* collective_cliques);
+
 }  // namespace xla::gpu
 
 #endif  // JAXMG_CUSOLVERMP_ROUTINES_H_

--- a/src/cuda/cusolvermp_routines/cusolvermp_syevd.cc
+++ b/src/cuda/cusolvermp_routines/cusolvermp_syevd.cc
@@ -45,7 +45,7 @@ namespace {
 // block-cyclic storage. The input is copied/aliased into work_out because
 // cuSOLVERMp overwrites d_A, while vectors_out is passed as the separate d_Z
 // eigenvector output. This helper owns descriptors, workspace allocation, the
-// installed-runtime compz selector, and info/status reporting.
+// installed-runtime jobz selector, and info/status reporting.
 template <typename DataType>
 absl::Status RunCusolverMpSyevd(
     const CusolverMpApi& api, cusolverMpHandle_t handle,
@@ -132,19 +132,17 @@ absl::Status RunCusolverMpSyevd(
 
   size_t workspace_device = 0;
   size_t workspace_host = 0;
-  // cuSOLVERMp 0.7.x exposes this selector as `compz` and NVIDIA's
-  // distributed SYEVD sample uses 'Z' for the eigenvector-producing path. Keep
-  // this aligned with the installed header/runtime rather than the newer
-  // `jobz='V'` wording in some versions of the public documentation.
-  char compz[] = {'Z', '\0'};
+  // cuSOLVERMp 0.9 uses jobz='V' to request eigenvalues and eigenvectors.
+  // JAXMg currently exposes only this vector-producing SYEVD path.
+  char jobz[] = {'V', '\0'};
   void* z_data = vectors_out->untyped_data();
   CusolverMpDebug(
       debug_rank,
-      "syevd_buffer_size begin compz=%c a=%p evals=%p z=%p desc_a=%p desc_q=%p",
-      compz[0], work_out->untyped_data(), eigenvalues_out->untyped_data(),
+      "syevd_buffer_size begin jobz=%c a=%p evals=%p z=%p desc_a=%p desc_q=%p",
+      jobz[0], work_out->untyped_data(), eigenvalues_out->untyped_data(),
       z_data, desc_a, desc_q);
   status = api.syevd_buffer_size(
-      handle, compz, CUBLAS_FILL_MODE_LOWER, n, work_out->untyped_data(),
+      handle, jobz, CUBLAS_FILL_MODE_LOWER, n, work_out->untyped_data(),
       /*IA=*/1, /*JA=*/1, desc_a, eigenvalues_out->untyped_data(),
       z_data, /*IQ=*/1, /*JQ=*/1, desc_q,
       SolverTraits<DataType>::cuda_data_type, &workspace_device,
@@ -199,7 +197,7 @@ absl::Status RunCusolverMpSyevd(
   JAXMG_RETURN_IF_CUDA_ERROR(cudaStreamSynchronize(cuda_stream));
 
   CusolverMpDebug(debug_rank, "syevd begin");
-  status = api.syevd(handle, compz, CUBLAS_FILL_MODE_LOWER, n,
+  status = api.syevd(handle, jobz, CUBLAS_FILL_MODE_LOWER, n,
                      work_out->untyped_data(), /*IA=*/1, /*JA=*/1, desc_a,
                      eigenvalues_out->untyped_data(), z_data, /*IQ=*/1,
                      /*JQ=*/1, desc_q,

--- a/src/cuda/cusolvermp_routines/cusolvermp_syevd.cc
+++ b/src/cuda/cusolvermp_routines/cusolvermp_syevd.cc
@@ -14,10 +14,11 @@
 //
 // cuSOLVERMp symmetric/Hermitian eigensolver FFI handler.
 //
-// This file implements the fused vector-producing SYEVD path. It converts a
-// padded JAX shard to column-major storage, redistributes it into cuSOLVERMp's
-// 2D block-cyclic layout, runs SYEVD through the XLA-owned NCCL communicator,
-// and restores the eigenvectors to their original JAX layout.
+// This file implements the fused SYEVD paths. Both modes convert a padded JAX
+// shard to column-major storage, redistribute it into cuSOLVERMp's 2D
+// block-cyclic layout, and run SYEVD through the XLA-owned NCCL communicator.
+// The vector-producing path additionally restores the distributed
+// eigenvectors to their original JAX layout.
 //
 // File workflow:
 //   1. Validate the padded matrix and output-buffer contracts.
@@ -25,10 +26,10 @@
 //   3. Convert the local matrix from row-major to column-major.
 //   4. Compact edge padding and redistribute the matrix into 2D block-cyclic
 //      cuSOLVERMp storage.
-//   5. Borrow the XLA communicator's NCCL handle and compute eigenvalues and
-//      eigenvectors with SYEVD.
-//   6. Reverse the redistribution for the eigenvectors.
-//   7. Restore their local row-major JAX storage.
+//   5. Borrow the XLA communicator's NCCL handle and run eigenvalues-only or
+//      vector-producing SYEVD.
+//   6. For the vector-producing path, reverse the eigenvector redistribution.
+//   7. Restore eigenvectors to local row-major JAX storage when requested.
 
 #include <array>
 #include <cstdlib>
@@ -39,13 +40,15 @@
 namespace xla::gpu {
 namespace {
 
-// Executes vector-producing cuSOLVERMp SYEVD on redistributed matrix storage.
+// Executes cuSOLVERMp SYEVD on redistributed matrix storage.
 //
 // memory_redist has already converted A into local column-major 2D
 // block-cyclic storage. The input is copied/aliased into work_out because
-// cuSOLVERMp overwrites d_A, while vectors_out is passed as the separate d_Z
-// eigenvector output. This helper owns descriptors, workspace allocation, the
-// installed-runtime jobz selector, and info/status reporting.
+// cuSOLVERMp overwrites d_A. When eigenvectors are requested, vectors_out is
+// passed as the separate d_Q output. For eigenvalues-only execution the unused
+// Q arguments reuse d_A and descA, avoiding an additional matrix allocation
+// without relying on undocumented null-pointer support. This helper owns
+// descriptors, workspace allocation, the jobz selector, and info reporting.
 template <typename DataType>
 absl::Status RunCusolverMpSyevd(
     const CusolverMpApi& api, cusolverMpHandle_t handle,
@@ -54,7 +57,7 @@ absl::Status RunCusolverMpSyevd(
     int64_t local_physical_cols, int32_t process_row, int32_t process_col,
     ffi::AnyBuffer a, ffi::Result<ffi::AnyBuffer> eigenvalues_out,
     ffi::Result<ffi::AnyBuffer> work_out,
-    ffi::Result<ffi::AnyBuffer> vectors_out,
+    ffi::AnyBuffer* vectors_out, bool compute_eigenvectors,
     std::array<int32_t, kSyevdStatusSize>* status_words) {
   const int debug_rank = (*status_words)[2];
   const int32_t process_rows = (*status_words)[4];
@@ -82,6 +85,7 @@ absl::Status RunCusolverMpSyevd(
 
   cusolverMpMatrixDescriptor_t desc_a = nullptr;
   cusolverMpMatrixDescriptor_t desc_q = nullptr;
+  bool owns_desc_q = false;
   CusolverMpDebug(debug_rank, "create desc_a begin");
   cusolverStatus_t status = api.create_matrix_desc(
       &desc_a, grid, SolverTraits<DataType>::cuda_data_type, n, n, tile_size,
@@ -94,20 +98,29 @@ absl::Status RunCusolverMpSyevd(
     return absl::OkStatus();
   }
   (*status_words)[10] = 1;
+  desc_q = desc_a;
 
-  CusolverMpDebug(debug_rank, "create desc_q begin");
-  status = api.create_matrix_desc(
-      &desc_q, grid, SolverTraits<DataType>::cuda_data_type, n, n, tile_size,
-      tile_size, /*RSRC_Q=*/0, /*CSRC_Q=*/0, local_physical_rows);
-  CusolverMpDebug(debug_rank, "create desc_q end status=%d desc=%p",
-                  static_cast<int>(status), desc_q);
-  if (status != CUSOLVER_STATUS_SUCCESS || desc_q == nullptr) {
-    (*status_words)[0] = kCreateMatrixDescFailed;
-    (*status_words)[11] = static_cast<int32_t>(status);
-    api.destroy_matrix_desc(desc_a);
-    return absl::OkStatus();
+  if (compute_eigenvectors) {
+    if (vectors_out == nullptr) {
+      (*status_words)[0] = kOutputShapeMismatch;
+      api.destroy_matrix_desc(desc_a);
+      return absl::OkStatus();
+    }
+    CusolverMpDebug(debug_rank, "create desc_q begin");
+    status = api.create_matrix_desc(
+        &desc_q, grid, SolverTraits<DataType>::cuda_data_type, n, n, tile_size,
+        tile_size, /*RSRC_Q=*/0, /*CSRC_Q=*/0, local_physical_rows);
+    CusolverMpDebug(debug_rank, "create desc_q end status=%d desc=%p",
+                    static_cast<int>(status), desc_q);
+    if (status != CUSOLVER_STATUS_SUCCESS || desc_q == nullptr) {
+      (*status_words)[0] = kCreateMatrixDescFailed;
+      (*status_words)[11] = static_cast<int32_t>(status);
+      api.destroy_matrix_desc(desc_a);
+      return absl::OkStatus();
+    }
+    owns_desc_q = true;
+    (*status_words)[27] = 1;
   }
-  (*status_words)[27] = 1;
 
   void* d_work = nullptr;
   void* h_work = nullptr;
@@ -116,13 +129,16 @@ absl::Status RunCusolverMpSyevd(
     if (d_work != nullptr) cudaFree(d_work);
     if (d_info != nullptr) cudaFree(d_info);
     if (h_work != nullptr) std::free(h_work);
-    api.destroy_matrix_desc(desc_q);
+    if (owns_desc_q) {
+      api.destroy_matrix_desc(desc_q);
+    }
     api.destroy_matrix_desc(desc_a);
   };
 
-  // cuSOLVERMp SYEVD overwrites d_A and writes eigenvectors to d_Z when
-  // requested. Keep those buffers distinct: the donated JAX input aliases the
-  // work output used as d_A, while the public eigenvector result is d_Z.
+  // cuSOLVERMp SYEVD overwrites d_A and writes eigenvectors to d_Q when
+  // requested. Keep those buffers distinct in vector mode: the donated JAX
+  // input aliases the work output used as d_A, while the public eigenvector
+  // result is d_Q.
   CusolverMpDebug(debug_rank, "copy input to work begin a=%p work=%p bytes=%lld",
                   a.untyped_data(), work_out->untyped_data(),
                   static_cast<long long>(a.size_bytes()));
@@ -132,19 +148,18 @@ absl::Status RunCusolverMpSyevd(
 
   size_t workspace_device = 0;
   size_t workspace_host = 0;
-  // cuSOLVERMp 0.9 uses jobz='V' to request eigenvalues and eigenvectors.
-  // JAXMg currently exposes only this vector-producing SYEVD path.
-  char jobz[] = {'V', '\0'};
-  void* z_data = vectors_out->untyped_data();
+  char jobz[] = {compute_eigenvectors ? 'V' : 'N', '\0'};
+  void* q_data = compute_eigenvectors ? vectors_out->untyped_data()
+                                      : work_out->untyped_data();
   CusolverMpDebug(
-      debug_rank,
-      "syevd_buffer_size begin jobz=%c a=%p evals=%p z=%p desc_a=%p desc_q=%p",
+      debug_rank, "syevd_buffer_size begin jobz=%c a=%p evals=%p q=%p "
+                  "desc_a=%p desc_q=%p",
       jobz[0], work_out->untyped_data(), eigenvalues_out->untyped_data(),
-      z_data, desc_a, desc_q);
+      q_data, desc_a, desc_q);
   status = api.syevd_buffer_size(
       handle, jobz, CUBLAS_FILL_MODE_LOWER, n, work_out->untyped_data(),
       /*IA=*/1, /*JA=*/1, desc_a, eigenvalues_out->untyped_data(),
-      z_data, /*IQ=*/1, /*JQ=*/1, desc_q,
+      q_data, /*IQ=*/1, /*JQ=*/1, desc_q,
       SolverTraits<DataType>::cuda_data_type, &workspace_device,
       &workspace_host);
   CusolverMpDebug(debug_rank,
@@ -199,7 +214,7 @@ absl::Status RunCusolverMpSyevd(
   CusolverMpDebug(debug_rank, "syevd begin");
   status = api.syevd(handle, jobz, CUBLAS_FILL_MODE_LOWER, n,
                      work_out->untyped_data(), /*IA=*/1, /*JA=*/1, desc_a,
-                     eigenvalues_out->untyped_data(), z_data, /*IQ=*/1,
+                     eigenvalues_out->untyped_data(), q_data, /*IQ=*/1,
                      /*JQ=*/1, desc_q,
                      SolverTraits<DataType>::cuda_data_type, d_work,
                      workspace_device, h_work, workspace_host, d_info);
@@ -229,37 +244,38 @@ absl::Status RunCusolverMpSyevd(
   return absl::OkStatus();
 }
 
-
 // Creates the borrowed-XLA-communicator cuSOLVERMp handle/grid and dispatches
-// the dtype-specific vector-producing SYEVD helper.
+// the dtype-specific SYEVD helper for the selected output mode.
 absl::Status RunCusolverMpSyevdSolver(
     se::Stream* stream, se::Stream* comm_stream, cudaStream_t cuda_stream,
     int64_t process_rows, int64_t process_cols, int64_t n,
     int64_t tile_size, int64_t grid_mapping,
     absl::Span<const int64_t> rank_map, ffi::AnyBuffer a,
     ffi::Result<ffi::AnyBuffer> eigenvalues_out,
-    ffi::Result<ffi::AnyBuffer> work_out,
-    ffi::Result<ffi::AnyBuffer> vectors_out,
+    ffi::Result<ffi::AnyBuffer> work_out, ffi::AnyBuffer* vectors_out,
+    bool compute_eigenvectors,
     ffi::Result<ffi::BufferR1<S32>> status_out,
     const CollectiveParams* collective_params,
     const CollectiveCliques* collective_cliques) {
   (void)comm_stream;
-  // Stage 1: validate the local FFI buffers.  SYEVD has three matrix buffers:
-  // the redistributed input A, work_out used as cuSOLVERMp's overwritten d_A,
-  // and vectors_out used as cuSOLVERMp's d_Z eigenvector output.
+  // Stage 1: validate the local FFI buffers. Both modes use the redistributed
+  // input A and work_out as cuSOLVERMp's overwritten d_A. Vector mode also
+  // receives vectors_out as the separate d_Q eigenvector output.
   if (stream == nullptr || cuda_stream == nullptr) {
     return absl::InvalidArgumentError(
         "cusolvermp_syevd requires XLA and CUDA streams");
   }
   if (a.dimensions().size() != 2 || work_out->dimensions().size() != 2 ||
-      vectors_out->dimensions().size() != 2 ||
-      eigenvalues_out->dimensions().size() != 1) {
+      eigenvalues_out->dimensions().size() != 1 ||
+      (compute_eigenvectors &&
+       (vectors_out == nullptr || vectors_out->dimensions().size() != 2))) {
     return absl::InvalidArgumentError(
         "cusolvermp_syevd expects rank-2 matrix buffers and rank-1 "
         "eigenvalue output");
   }
   if (a.element_type() != work_out->element_type() ||
-      a.element_type() != vectors_out->element_type()) {
+      (compute_eigenvectors &&
+       a.element_type() != vectors_out->element_type())) {
     return absl::InvalidArgumentError(
         "cusolvermp_syevd requires matching matrix/work/vector dtypes");
   }
@@ -271,8 +287,9 @@ absl::Status RunCusolverMpSyevdSolver(
   }
   if (a.dimensions()[0] != work_out->dimensions()[0] ||
       a.dimensions()[1] != work_out->dimensions()[1] ||
-      a.dimensions()[0] != vectors_out->dimensions()[0] ||
-      a.dimensions()[1] != vectors_out->dimensions()[1]) {
+      (compute_eigenvectors &&
+       (a.dimensions()[0] != vectors_out->dimensions()[0] ||
+        a.dimensions()[1] != vectors_out->dimensions()[1]))) {
     return absl::InvalidArgumentError(
         "cusolvermp_syevd input/output matrix shapes must match");
   }
@@ -307,7 +324,7 @@ absl::Status RunCusolverMpSyevdSolver(
       -1,  // local NUMROC rows.
       -1,  // local NUMROC cols.
       static_cast<int32_t>(eigenvalues_out->size_bytes()),
-      1,   // vector-producing SYEVD path.
+      static_cast<int32_t>(compute_eigenvectors),  // Eigenvectors requested.
       -1,  // syevd device workspace, KiB.
       -1,  // syevd host workspace, KiB.
       0,   // cusolverMpSyevd called.
@@ -340,11 +357,12 @@ absl::Status RunCusolverMpSyevdSolver(
   }
   status_words[1] = cuda_device;
   CusolverMpDebug(-1, "syevd dispatch device=%d n=%lld tile=%lld grid=%lldx%lld "
-                      "vectors=1",
+                      "vectors=%d",
                   cuda_device, static_cast<long long>(n),
                   static_cast<long long>(tile_size),
                   static_cast<long long>(process_rows),
-                  static_cast<long long>(process_cols));
+                  static_cast<long long>(process_cols),
+                  compute_eigenvectors ? 1 : 0);
 
   // Stage 3: borrow the XLA-created NCCL communicator for this rank.  The
   // communicator rank is then converted to a cuSOLVERMp process-grid
@@ -459,8 +477,8 @@ absl::Status RunCusolverMpSyevdSolver(
   CusolverMpDebug(nccl_rank, "dispatch process_coord=(%d,%d) element_type=%d",
                   process_row, process_col, static_cast<int>(a.element_type()));
 
-  // Stage 6: dispatch on dtype and run the shared SYEVD helper.  The helper
-  // keeps d_A and d_Z separate because vector-producing SYEVD overwrites A.
+  // Stage 6: dispatch on dtype and run the shared SYEVD helper. Vector mode
+  // keeps d_A and d_Q separate; values-only mode does not allocate d_Q.
   absl::Status syevd_status;
   switch (a.element_type()) {
     case F32:
@@ -468,28 +486,28 @@ absl::Status RunCusolverMpSyevdSolver(
       syevd_status = RunCusolverMpSyevd<float>(
           api, handle, grid, cuda_stream, n, tile_size, a.dimensions()[0],
           a.dimensions()[1], process_row, process_col, a, eigenvalues_out,
-          work_out, vectors_out, &status_words);
+          work_out, vectors_out, compute_eigenvectors, &status_words);
       break;
     case F64:
       status_words[25] = 2;
       syevd_status = RunCusolverMpSyevd<double>(
           api, handle, grid, cuda_stream, n, tile_size, a.dimensions()[0],
           a.dimensions()[1], process_row, process_col, a, eigenvalues_out,
-          work_out, vectors_out, &status_words);
+          work_out, vectors_out, compute_eigenvectors, &status_words);
       break;
     case C64:
       status_words[25] = 3;
       syevd_status = RunCusolverMpSyevd<cuFloatComplex>(
           api, handle, grid, cuda_stream, n, tile_size, a.dimensions()[0],
           a.dimensions()[1], process_row, process_col, a, eigenvalues_out,
-          work_out, vectors_out, &status_words);
+          work_out, vectors_out, compute_eigenvectors, &status_words);
       break;
     case C128:
       status_words[25] = 4;
       syevd_status = RunCusolverMpSyevd<cuDoubleComplex>(
           api, handle, grid, cuda_stream, n, tile_size, a.dimensions()[0],
           a.dimensions()[1], process_row, process_col, a, eigenvalues_out,
-          work_out, vectors_out, &status_words);
+          work_out, vectors_out, compute_eigenvectors, &status_words);
       break;
     default:
       status_words[0] = kUnsupportedDtype;
@@ -524,7 +542,6 @@ absl::Status RunCusolverMpSyevdSolver(
   return CopySyevdStatusToDevice(stream, status_words, status_out);
 }
 
-
 }  // namespace
 
 // Prepare only requests the communicator clique.  The dispatch path later
@@ -537,35 +554,43 @@ absl::Status XlaCusolverMpSyevdPrepare(
       collective_params, clique_requests, "cusolvermp_syevd");
 }
 
-// Executes the complete vector-producing SYEVD workflow in one FFI dispatch.
-// The overwritten matrix work buffer remains distinct from the eigenvector
-// output required by the cuSOLVERMp API.
-absl::Status XlaCusolverMpSyevdDispatch(
+namespace {
+
+// Executes the shared native SYEVD workflow for either output mode.
+//
+// Both paths prepare A in 2D block-cyclic form and invoke the same
+// cuSOLVERMp/NCCL setup. Vector mode additionally receives a matrix-sized Q
+// output and restores it to the original JAX layout. Values-only mode omits
+// that output and ends after the solver has produced the replicated spectrum.
+absl::Status RunCusolverMpSyevdDispatch(
     se::Stream* stream, se::Stream* comm_stream, cudaStream_t cuda_stream,
     int64_t process_rows, int64_t process_cols, int64_t n, int64_t tile_size,
     int64_t grid_mapping, absl::Span<const int64_t> rank_map, ffi::AnyBuffer a,
     ffi::Result<ffi::AnyBuffer> eigenvalues,
-    ffi::Result<ffi::AnyBuffer> work, ffi::Result<ffi::AnyBuffer> vectors,
+    ffi::Result<ffi::AnyBuffer> work, ffi::AnyBuffer* vectors,
+    bool compute_eigenvectors,
     ffi::Result<ffi::BufferR1<S32>> status,
     const CollectiveParams* collective_params,
     const CollectiveCliques* collective_cliques) {
-  // Stage 1: validate the local FFI buffers.  The public Python wrapper has
-  // already padded A to tile-aligned capacity and allocated work/vectors with
-  // the same local matrix capacity.
+  // Stage 1: validate the local FFI buffers. The Python wrapper has already
+  // padded A to tile-aligned capacity. Work has the same local matrix capacity,
+  // and vector mode supplies a matching Q output.
   if (a.dimensions().size() != 2 || work->dimensions().size() != 2 ||
-      vectors->dimensions().size() != 2) {
+      (compute_eigenvectors &&
+       (vectors == nullptr || vectors->dimensions().size() != 2))) {
     return absl::InvalidArgumentError(
         "cusolvermp_syevd expects rank-2 matrix buffers");
   }
   if (a.element_type() != work->element_type() ||
-      a.element_type() != vectors->element_type()) {
+      (compute_eigenvectors && a.element_type() != vectors->element_type())) {
     return absl::InvalidArgumentError(
         "cusolvermp_syevd requires matching matrix dtypes");
   }
   if (a.dimensions()[0] != work->dimensions()[0] ||
       a.dimensions()[1] != work->dimensions()[1] ||
-      a.dimensions()[0] != vectors->dimensions()[0] ||
-      a.dimensions()[1] != vectors->dimensions()[1]) {
+      (compute_eigenvectors &&
+       (a.dimensions()[0] != vectors->dimensions()[0] ||
+        a.dimensions()[1] != vectors->dimensions()[1]))) {
     return absl::InvalidArgumentError(
         "cusolvermp_syevd input/output matrix shapes must match");
   }
@@ -669,14 +694,20 @@ absl::Status XlaCusolverMpSyevdDispatch(
   }
 
   ffi::AnyBuffer a_cyclic = *work;
-  // Stage 5: run vector-producing SYEVD.  The helper creates cuSOLVERMp
-  // descriptors for A and Q and writes eigenvectors into `vectors`.
+  // Stage 5: run SYEVD in the statically selected mode. The shared helper
+  // creates a Q descriptor only when eigenvectors are requested.
   if (absl::Status solver_call_status = RunCusolverMpSyevdSolver(
           stream, comm_stream, cuda_stream, process_rows, process_cols, n,
           tile_size, grid_mapping, rank_map, a_cyclic, eigenvalues, work,
-          vectors, status, collective_params, collective_cliques);
+          vectors, compute_eigenvectors, status, collective_params,
+          collective_cliques);
       !solver_call_status.ok()) {
     return return_after_cleanup(solver_call_status);
+  }
+
+  // Values-only SYEVD has no matrix result to redistribute or restore.
+  if (!compute_eigenvectors) {
+    return return_after_cleanup(absl::OkStatus());
   }
 
   // Complete the solver call before reverse redistribution reads eigenvectors.
@@ -710,6 +741,46 @@ absl::Status XlaCusolverMpSyevdDispatch(
     return return_after_cleanup(status);
   }
   return return_after_cleanup(absl::OkStatus());
+}
+
+}  // namespace
+
+// Executes the complete vector-producing SYEVD workflow in one FFI dispatch.
+// The overwritten matrix work buffer remains distinct from the eigenvector
+// output required by the cuSOLVERMp API.
+absl::Status XlaCusolverMpSyevdDispatch(
+    se::Stream* stream, se::Stream* comm_stream, cudaStream_t cuda_stream,
+    int64_t process_rows, int64_t process_cols, int64_t n, int64_t tile_size,
+    int64_t grid_mapping, absl::Span<const int64_t> rank_map, ffi::AnyBuffer a,
+    ffi::Result<ffi::AnyBuffer> eigenvalues,
+    ffi::Result<ffi::AnyBuffer> work, ffi::Result<ffi::AnyBuffer> vectors,
+    ffi::Result<ffi::BufferR1<S32>> status,
+    const CollectiveParams* collective_params,
+    const CollectiveCliques* collective_cliques) {
+  ffi::AnyBuffer vector_buffer = *vectors;
+  return RunCusolverMpSyevdDispatch(
+      stream, comm_stream, cuda_stream, process_rows, process_cols, n,
+      tile_size, grid_mapping, rank_map, a, eigenvalues, work, &vector_buffer,
+      /*compute_eigenvectors=*/true, status, collective_params,
+      collective_cliques);
+}
+
+// Executes eigenvalues-only SYEVD without allocating or restoring a
+// matrix-sized eigenvector output.
+absl::Status XlaCusolverMpSyevdValuesDispatch(
+    se::Stream* stream, se::Stream* comm_stream, cudaStream_t cuda_stream,
+    int64_t process_rows, int64_t process_cols, int64_t n, int64_t tile_size,
+    int64_t grid_mapping, absl::Span<const int64_t> rank_map, ffi::AnyBuffer a,
+    ffi::Result<ffi::AnyBuffer> eigenvalues,
+    ffi::Result<ffi::AnyBuffer> work,
+    ffi::Result<ffi::BufferR1<S32>> status,
+    const CollectiveParams* collective_params,
+    const CollectiveCliques* collective_cliques) {
+  return RunCusolverMpSyevdDispatch(
+      stream, comm_stream, cuda_stream, process_rows, process_cols, n,
+      tile_size, grid_mapping, rank_map, a, eigenvalues, work,
+      /*vectors=*/nullptr, /*compute_eigenvectors=*/false, status,
+      collective_params, collective_cliques);
 }
 
 }  // namespace xla::gpu

--- a/src/cuda/xla_ffi/handlers.cc
+++ b/src/cuda/xla_ffi/handlers.cc
@@ -148,8 +148,8 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
         .Ctx<ffi::CollectiveParams>()
         .Ctx<ffi::CollectiveCliqueRequests>());
 
-// Registers the runtime SYEVD target that returns eigenvalues, eigenvectors,
-// solver work storage, and a status vector.
+// Registers the runtime SYEVD target that returns eigenvalues, solver work
+// storage, eigenvectors, and a status vector.
 XLA_FFI_DEFINE_HANDLER_SYMBOL(
     XlaCusolverMpSyevdFFI, XlaCusolverMpSyevdDispatch,
     ffi::Ffi::Bind()
@@ -164,6 +164,27 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
         .Attr<absl::Span<const int64_t>>("rank_map")
         .Arg<ffi::AnyBuffer>()
         .Ret<ffi::AnyBuffer>()
+        .Ret<ffi::AnyBuffer>()
+        .Ret<ffi::AnyBuffer>()
+        .Ret<ffi::BufferR1<S32>>()
+        .Ctx<ffi::CollectiveParams>()
+        .Ctx<ffi::CollectiveCliques>());
+
+// Registers the eigenvalues-only SYEVD target. Omitting the eigenvector result
+// prevents XLA from allocating an unused matrix-sized output.
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    XlaCusolverMpSyevdValuesFFI, XlaCusolverMpSyevdValuesDispatch,
+    ffi::Ffi::Bind()
+        .Ctx<ffi::Stream>()
+        .Ctx<ffi::CommunicationStream<1>>()
+        .Ctx<ffi::PlatformStream<cudaStream_t>>()
+        .Attr<int64_t>("process_rows")
+        .Attr<int64_t>("process_cols")
+        .Attr<int64_t>("n")
+        .Attr<int64_t>("tile_size")
+        .Attr<int64_t>("grid_mapping")
+        .Attr<absl::Span<const int64_t>>("rank_map")
+        .Arg<ffi::AnyBuffer>()
         .Ret<ffi::AnyBuffer>()
         .Ret<ffi::AnyBuffer>()
         .Ret<ffi::BufferR1<S32>>()

--- a/src/jaxmg/__init__.py
+++ b/src/jaxmg/__init__.py
@@ -8,7 +8,7 @@ native FFI to achieve scalable performance on distributed GPU clusters.
 Main Entry Points:
     - :func:`jaxmg.potrs`: Solve ``A x = B`` for positive-definite ``A``.
     - :func:`jaxmg.lu_solve`: Solve ``A x = B`` for general nonsingular ``A``.
-    - :func:`jaxmg.syevd`: Compute eigenvalues and eigenvectors.
+    - :func:`jaxmg.syevd`: Compute eigenvalues and optional eigenvectors.
 """
 
 from importlib.metadata import version

--- a/src/jaxmg/_setup.py
+++ b/src/jaxmg/_setup.py
@@ -57,6 +57,13 @@ _PRODUCTION_FFI_TARGETS = (
             "execute": "XlaCusolverMpSyevdFFI",
         },
     ),
+    (
+        "cusolvermp_syevd_values",
+        {
+            "prepare": "XlaCusolverMpSyevdPrepareFFI",
+            "execute": "XlaCusolverMpSyevdValuesFFI",
+        },
+    ),
 )
 
 if not sys.platform.startswith("linux"):

--- a/src/jaxmg/_syevd.py
+++ b/src/jaxmg/_syevd.py
@@ -1,10 +1,11 @@
 """Public cuSOLVERMp symmetric/Hermitian eigensolver wrapper.
 
-Only eigenvector-producing SYEVD is exposed.  The Python layer validates JAX
-array metadata, applies per-shard tile padding, and constructs the compiled FFI
-call.  The native backend converts local storage to cuSOLVERMp's column-major
-layout, redistributes into 2D block-cyclic form, calls ``cusolverMpSyevd``, and
-returns eigenvalues plus eigenvectors in the original JAX-facing layout.
+The Python layer validates JAX array metadata, applies per-shard tile padding,
+and constructs the compiled FFI call for eigenvalues-only or vector-producing
+SYEVD. The native backend converts local storage to cuSOLVERMp's column-major
+layout, redistributes into 2D block-cyclic form, and calls
+``cusolverMpSyevd``. Eigenvectors are restored to the original JAX-facing
+layout only when requested.
 """
 
 from __future__ import annotations
@@ -41,16 +42,19 @@ def syevd(
     matrix_specs: P | Tuple[P] | List[P] | None = None,
     *,
     in_specs: P | Tuple[P] | List[P] | None = None,
+    return_eigenvectors: bool = True,
     return_status: bool = False,
     pad: bool = True,
-) -> Tuple[Array, Array] | Tuple[Array, Array, Array]:
-    """Compute eigenvalues and eigenvectors using the multi-GPU syevd kernel.
+) -> Array | Tuple[Array, Array] | Tuple[Array, Array, Array]:
+    """Compute eigenvalues and optionally eigenvectors using multi-GPU SYEVD.
 
     This is the high-level JAXMg symmetric/Hermitian eigensolver entry point.
     It accepts a block-sharded JAX matrix, prepares the tile-aligned local
-    capacity required by cuSOLVERMp, calls the fused native backend, and returns
-    eigenvalues together with eigenvectors in the same JAX-facing matrix layout
-    as the input.
+    capacity required by cuSOLVERMp, and calls the fused native backend. By
+    default it returns eigenvalues together with eigenvectors in the same
+    JAX-facing matrix layout as the input. Setting ``return_eigenvectors=False``
+    selects cuSOLVERMp's eigenvalues-only mode and avoids allocating or
+    restoring a matrix-sized eigenvector result.
 
     Note:
         If a local shard dimension is not divisible by ``T_A``, ``pad=True``
@@ -71,6 +75,10 @@ def syevd(
             PartitionSpec describing the matrix sharding. If omitted, inferred
             from ``a.sharding.spec``.
         in_specs: Backwards-compatible alias for ``matrix_specs``.
+        return_eigenvectors (bool, optional): If True (default), compute and
+            return eigenvectors as well as eigenvalues. If False, return only
+            eigenvalues and use the shorter native values-only workflow. This
+            must be a Python ``bool`` fixed while tracing.
         return_status (bool, optional): If True append a native per-rank
             diagnostic status vector to the return values. Default is False.
         pad (bool, optional): If True (default) apply per-device padding to
@@ -78,19 +86,21 @@ def syevd(
             correct shapes.
 
     Returns:
-        (eigenvalues, eigenvectors) or (eigenvalues, eigenvectors, status).
+        If ``return_eigenvectors=True``, ``(eigenvalues, eigenvectors)`` or
+        ``(eigenvalues, eigenvectors, status)``. If False, ``eigenvalues`` or
+        ``(eigenvalues, status)``.
 
     Raises:
         TypeError: If dtypes or ``PartitionSpec`` inputs are unsupported.
         ValueError: If shapes, tile sizes, or mesh layouts are incompatible.
 
     Notes:
-        - Only the eigenvector-producing mode is currently exposed.
         - The FFI call can donate the input buffer to enable zero-copy
           interaction with the native library.
         - Native code converts row-major JAX local storage to cuSOLVERMp's
-          column-major local layout, redistributes to 2D block-cyclic layout,
-          calls ``cusolverMpSyevd``, and redistributes the eigenvectors back.
+          column-major local layout and redistributes to 2D block-cyclic
+          layout. The eigenvector mode also redistributes its matrix result
+          back to the original JAX layout.
         - If the native solver fails the outputs may contain NaNs and the
           status, when requested, will be non-zero.
     """
@@ -101,6 +111,8 @@ def syevd(
         raise ValueError("syevd expects A to be square.")
     if int(T_A) <= 0:
         raise ValueError("T_A must be positive.")
+    if not isinstance(return_eigenvectors, bool):
+        raise TypeError("return_eigenvectors must be a Python bool.")
 
     mesh, matrix_specs = infer_mesh_and_matrix_specs(
         a,
@@ -146,8 +158,16 @@ def syevd(
         n=a.shape[0],
         tile_size=tile_shape.rows,
         dtype=a.dtype,
+        return_eigenvectors=return_eigenvectors,
     )
-    eigenvalues, _, vectors, native_status = impl(a)
+    outputs = impl(a)
+    if not return_eigenvectors:
+        eigenvalues, _, native_status = outputs
+        if return_status:
+            return eigenvalues, native_status
+        return eigenvalues
+
+    eigenvalues, _, vectors, native_status = outputs
     if return_status:
         return eigenvalues, vectors, native_status
     return eigenvalues, vectors
@@ -160,9 +180,10 @@ def syevd_shardmap_ctx(
     matrix_specs: P | Tuple[P] | List[P] | None = None,
     *,
     in_specs: P | Tuple[P] | List[P] | None = None,
+    return_eigenvectors: bool = True,
     pad: bool = True,
-) -> Tuple[Array, Array, Array, Array]:
-    """Compute eigenvalues and eigenvectors while exposing the donated work buffer.
+) -> Tuple[Array, Array, Array] | Tuple[Array, Array, Array, Array]:
+    """Compute eigenvalues and optional eigenvectors while exposing work storage.
 
     This helper is the lower-level variant of :func:`jaxmg.syevd` intended for
     contexts where the caller controls the outer ``jax.jit`` boundary. It
@@ -172,10 +193,11 @@ def syevd_shardmap_ctx(
     so an outer JIT can donate ``a`` into an ``A``-sized output.
 
     cuSOLVERMp uses separate distributed matrices for its overwritten input
-    ``d_A`` and eigenvector output ``d_Z``. The context interface therefore
+    ``d_A`` and eigenvector output ``d_Q``. The context interface therefore
     returns ``a_work`` to provide the outer compiled function with an
-    ``A``-sized alias target for the donated input. The returned eigenvectors
-    occupy a separate matrix-sized allocation.
+    ``A``-sized alias target for the donated input. When eigenvectors are
+    requested, they occupy a separate matrix-sized allocation. Values-only
+    execution omits that allocation and the associated reverse redistribution.
 
     Note:
         If a local shard dimension is not divisible by ``T_A``, ``pad=True``
@@ -196,16 +218,20 @@ def syevd_shardmap_ctx(
             PartitionSpec describing the matrix sharding. If omitted, inferred
             from ``a.sharding.spec``.
         in_specs: Backwards-compatible alias for ``matrix_specs``.
+        return_eigenvectors (bool, optional): If True (default), compute and
+            return eigenvectors as well as eigenvalues. If False, use the
+            eigenvalues-only native workflow. This must be a Python ``bool``
+            fixed while tracing.
         pad (bool, optional): If True (default) apply per-device padding to
             meet ``T_A`` requirements; if False the caller must supply already
             correct shapes.
 
     Returns:
-        tuple: ``(a_work, eigenvalues, eigenvectors, status)``. ``a_work`` is
-        the native matrix work output returned to preserve the donated input
-        alias and includes any padding applied by the normal pipeline.
-        ``eigenvalues`` is replicated and real-valued, ``eigenvectors`` has the
-        original logical matrix shape and sharding, and ``status`` is the
+        tuple: ``(a_work, eigenvalues, eigenvectors, status)`` when
+        ``return_eigenvectors=True``, otherwise
+        ``(a_work, eigenvalues, status)``. ``a_work`` preserves the donated
+        input alias and includes any padding applied by the normal pipeline.
+        ``eigenvalues`` is replicated and real-valued, and ``status`` is the
         native per-rank diagnostic vector.
 
     Raises:
@@ -217,10 +243,11 @@ def syevd_shardmap_ctx(
           ``a_work`` in the outer function's returned pytree so the donated
           matrix has an ``A``-sized output alias.
         - Returning ``a_work`` does not remove cuSOLVERMp's separate
-          eigenvector allocation.
+          eigenvector allocation when eigenvectors are requested.
         - Native code converts row-major JAX local storage to cuSOLVERMp's
           column-major local layout, redistributes to 2D block-cyclic layout,
-          calls ``cusolverMpSyevd``, and redistributes the eigenvectors back.
+          calls ``cusolverMpSyevd``, and redistributes eigenvectors back when
+          requested.
     """
     if a.ndim != 2:
         raise ValueError("syevd_shardmap_ctx expects a rank-2 matrix A.")
@@ -229,6 +256,8 @@ def syevd_shardmap_ctx(
         raise ValueError("syevd_shardmap_ctx expects A to be square.")
     if int(T_A) <= 0:
         raise ValueError("T_A must be positive.")
+    if not isinstance(return_eigenvectors, bool):
+        raise TypeError("return_eigenvectors must be a Python bool.")
 
     mesh, matrix_specs = infer_mesh_and_matrix_specs(
         a,
@@ -274,8 +303,14 @@ def syevd_shardmap_ctx(
         n=a.shape[0],
         tile_size=tile_shape.rows,
         dtype=a.dtype,
+        return_eigenvectors=return_eigenvectors,
     )
-    eigenvalues, a_work, eigenvectors, native_status = impl(a)
+    outputs = impl(a)
+    if not return_eigenvectors:
+        eigenvalues, a_work, native_status = outputs
+        return a_work, eigenvalues, native_status
+
+    eigenvalues, a_work, eigenvectors, native_status = outputs
     return a_work, eigenvalues, eigenvectors, native_status
 
 
@@ -389,14 +424,15 @@ def _syevd_pipeline(
     n: int,
     tile_size: int,
     dtype,
+    return_eigenvectors: bool,
 ):
     """Build and cache the unjitted JAX-visible SYEVD execution pipeline.
 
     The cache key is the static solver configuration: mesh, sharding spec,
     process-grid shape, rank mapping, padded local shape, matrix size, tile
-    size, and dtype. Reusing this factory avoids rebuilding the same
-    ``jax.shard_map`` structure for repeated eigensolves with identical layout
-    metadata.
+    size, dtype, and output mode. Reusing this factory avoids rebuilding the
+    same ``jax.shard_map`` structure for repeated eigensolves with identical
+    layout metadata.
     """
     process_rows = grid.process_rows
     process_cols = grid.process_cols
@@ -414,15 +450,27 @@ def _syevd_pipeline(
         caller="cusolvermp_syevd",
     )
     pad_a = _make_local_pad_fn(mesh, matrix_specs, a_padding)
-    unpad_vectors = _make_local_unpad_fn(
-        mesh,
-        matrix_specs,
-        local_rows=a_padding.local_logical_rows,
-        local_cols=a_padding.local_logical_cols,
-    )
+    if return_eigenvectors:
+        unpad_vectors = _make_local_unpad_fn(
+            mesh,
+            matrix_specs,
+            local_rows=a_padding.local_logical_rows,
+            local_cols=a_padding.local_logical_cols,
+        )
+        ffi_target = "cusolvermp_syevd"
+        out_specs = (
+            P(None),
+            matrix_specs,
+            matrix_specs,
+            native_status_specs,
+        )
+    else:
+        unpad_vectors = None
+        ffi_target = "cusolvermp_syevd_values"
+        out_specs = (P(None), matrix_specs, native_status_specs)
 
-    def syevd_ffi(_a: Array) -> tuple[Array, Array, Array, Array]:
-        """Call fused native redistribution and vector-producing ``syevd``.
+    def syevd_ffi(_a: Array):
+        """Call fused native redistribution and the selected SYEVD mode.
 
         This function is mapped over local shards.  It declares the native FFI
         symbol, buffer layouts, result shapes, and static process-grid metadata;
@@ -432,23 +480,31 @@ def _syevd_pipeline(
             raise ValueError("cusolvermp_syevd expects a rank-2 matrix buffer.")
         _check_supported_syevd_dtype(_a.dtype)
 
-        out_type = (
-            jax.ShapeDtypeStruct((int(n),), _real_dtype_for_eigenvalues(dtype)),
-            jax.ShapeDtypeStruct(_a.shape, _a.dtype),
-            jax.ShapeDtypeStruct(_a.shape, _a.dtype),
-            jax.ShapeDtypeStruct((_CUSOLVERMP_SYEVD_STATUS_SIZE,), jnp.int32),
+        eigenvalue_type = jax.ShapeDtypeStruct(
+            (int(n),), _real_dtype_for_eigenvalues(dtype)
         )
+        matrix_type = jax.ShapeDtypeStruct(_a.shape, _a.dtype)
+        status_type = jax.ShapeDtypeStruct(
+            (_CUSOLVERMP_SYEVD_STATUS_SIZE,), jnp.int32
+        )
+        if return_eigenvectors:
+            out_type = (eigenvalue_type, matrix_type, matrix_type, status_type)
+            output_layouts = (
+                (0,),
+                _ROW_MAJOR_JAX_LAYOUT,
+                _ROW_MAJOR_JAX_LAYOUT,
+                (0,),
+            )
+        else:
+            out_type = (eigenvalue_type, matrix_type, status_type)
+            output_layouts = ((0,), _ROW_MAJOR_JAX_LAYOUT, (0,))
+
         ffi_fn = partial(
             jax.ffi.ffi_call(
-                "cusolvermp_syevd",
+                ffi_target,
                 out_type,
                 input_layouts=(_ROW_MAJOR_JAX_LAYOUT,),
-                output_layouts=(
-                    (0,),
-                    _ROW_MAJOR_JAX_LAYOUT,
-                    _ROW_MAJOR_JAX_LAYOUT,
-                    (0,),
-                ),
+                output_layouts=output_layouts,
                 input_output_aliases={0: 1},
             ),
             process_rows=process_rows,
@@ -458,23 +514,24 @@ def _syevd_pipeline(
             n=int(n),
             tile_size=int(tile_size),
         )
-        eigenvalues, work, eigenvectors, status = ffi_fn(_a)
-        return eigenvalues, work, eigenvectors, status
+        return ffi_fn(_a)
 
     syevd_shardmap = jax.shard_map(
         syevd_ffi,
         mesh=mesh,
         in_specs=matrix_specs,
-        out_specs=(P(None), matrix_specs, matrix_specs, native_status_specs),
+        out_specs=out_specs,
         check_vma=False,
     )
 
-    def impl(_a: Array) -> tuple[Array, Array, Array, Array]:
-        """Run padding, fused native SYEVD, and eigenvector unpadding."""
+    def impl(_a: Array):
+        """Run padding, fused native SYEVD, and optional vector unpadding."""
         a_padded = pad_a(_a)
-        eigenvalues, work_padded, vectors_padded, native_status = syevd_shardmap(
-            a_padded
-        )
+        outputs = syevd_shardmap(a_padded)
+        if not return_eigenvectors:
+            return outputs
+
+        eigenvalues, work_padded, vectors_padded, native_status = outputs
         vectors = unpad_vectors(vectors_padded)
         return eigenvalues, work_padded, vectors, native_status
 
@@ -494,6 +551,7 @@ def _syevd_compiled(
     n: int,
     tile_size: int,
     dtype,
+    return_eigenvectors: bool,
 ):
     """Build and cache the internally jitted public SYEVD pipeline."""
     pipeline = _syevd_pipeline(
@@ -507,10 +565,11 @@ def _syevd_compiled(
         n=n,
         tile_size=tile_size,
         dtype=dtype,
+        return_eigenvectors=return_eigenvectors,
     )
 
     @partial(jax.jit, donate_argnums=(0,))
-    def impl(_a: Array) -> tuple[Array, Array, Array, Array]:
+    def impl(_a: Array):
         """Run the cached SYEVD pipeline behind the public convenience API."""
         return pipeline(_a)
 

--- a/tests/cpu_only/test_syevd_interface.py
+++ b/tests/cpu_only/test_syevd_interface.py
@@ -38,8 +38,8 @@ def _install_fake_syevd_backend(monkeypatch):
             )
             eigenvalues = jnp.arange(n, dtype=eigenvalue_dtype)
             status = jnp.zeros((_CUSOLVERMP_SYEVD_STATUS_SIZE,), dtype=jnp.int32)
-            # impl returns eigenvalues, the donated work buffer, eigenvectors,
-            # and status.
+            if not kwargs["return_eigenvectors"]:
+                return eigenvalues, _a, status
             return eigenvalues, _a, _a, status
 
         return impl
@@ -70,6 +70,40 @@ def test_syevd_accepts_current_2d_mesh_contract(monkeypatch):
     assert vectors.shape == a.shape
     assert captured["kwargs"]["n"] == 4
     assert captured["kwargs"]["tile_size"] == 2
+    assert captured["kwargs"]["return_eigenvectors"] is True
+
+
+def test_syevd_can_return_eigenvalues_only(monkeypatch):
+    captured = _install_fake_syevd_backend(monkeypatch)
+    a = jnp.eye(4, dtype=jnp.float32)
+
+    eigenvalues = syevd(
+        a,
+        2,
+        mesh=_one_rank_mesh(),
+        matrix_specs=P("pr", "pc"),
+        return_eigenvectors=False,
+    )
+
+    assert eigenvalues.shape == (4,)
+    assert captured["kwargs"]["return_eigenvectors"] is False
+
+
+def test_syevd_values_only_can_return_native_status(monkeypatch):
+    _install_fake_syevd_backend(monkeypatch)
+    a = jnp.eye(4, dtype=jnp.float64)
+
+    eigenvalues, status = syevd(
+        a,
+        2,
+        mesh=_one_rank_mesh(),
+        matrix_specs=P("pr", "pc"),
+        return_eigenvectors=False,
+        return_status=True,
+    )
+
+    assert eigenvalues.shape == (4,)
+    assert status.shape == (_CUSOLVERMP_SYEVD_STATUS_SIZE,)
 
 
 def test_syevd_can_return_native_status(monkeypatch):
@@ -104,6 +138,25 @@ def test_syevd_shardmap_ctx_returns_work_eigensystem_and_status(monkeypatch):
     assert status.shape == (_CUSOLVERMP_SYEVD_STATUS_SIZE,)
     assert captured["pipeline_kwargs"]["n"] == 4
     assert captured["pipeline_kwargs"]["tile_size"] == 2
+    assert captured["pipeline_kwargs"]["return_eigenvectors"] is True
+
+
+def test_syevd_shardmap_ctx_returns_values_only_work_and_status(monkeypatch):
+    captured = _install_fake_syevd_backend(monkeypatch)
+    a = jnp.eye(4, dtype=jnp.float32)
+
+    a_work, eigenvalues, status = syevd_shardmap_ctx(
+        a,
+        2,
+        mesh=_one_rank_mesh(),
+        matrix_specs=P("pr", "pc"),
+        return_eigenvectors=False,
+    )
+
+    assert a_work.shape == a.shape
+    assert eigenvalues.shape == (4,)
+    assert status.shape == (_CUSOLVERMP_SYEVD_STATUS_SIZE,)
+    assert captured["pipeline_kwargs"]["return_eigenvectors"] is False
 
 
 def test_syevd_shardmap_ctx_can_be_wrapped_in_external_jit(monkeypatch):
@@ -147,6 +200,33 @@ def test_syevd_external_jit_can_lower_from_shape_specs(monkeypatch):
     ).compile()
 
     assert compiled.memory_analysis() is not None
+
+
+def test_syevd_values_only_external_jit_can_lower(monkeypatch):
+    _install_fake_syevd_backend(monkeypatch)
+    mesh = _one_rank_mesh()
+    eigensolve = jax.jit(
+        partial(
+            syevd_shardmap_ctx,
+            T_A=2,
+            mesh=mesh,
+            matrix_specs=P("pr", "pc"),
+            return_eigenvectors=False,
+        ),
+        donate_argnums=(0,),
+    )
+
+    compiled = eigensolve.lower(
+        jax.ShapeDtypeStruct((4, 4), jnp.float32)
+    ).compile()
+
+    assert compiled.memory_analysis() is not None
+
+
+@pytest.mark.parametrize("value", [0, 1, "N", None])
+def test_syevd_rejects_non_boolean_return_eigenvectors(value):
+    with pytest.raises(TypeError, match="return_eigenvectors must be a Python bool"):
+        syevd(jnp.eye(4), 2, return_eigenvectors=value)
 
 
 def test_syevd_rejects_non_matrix_a():

--- a/tests/mpmd/run_syevd.py
+++ b/tests/mpmd/run_syevd.py
@@ -32,6 +32,9 @@ num_procs = int(sys.argv[3])
 case_name = sys.argv[4]
 dtype_name = sys.argv[5]
 interface = os.environ.get("JAXMG_TEST_INTERFACE", "public")
+return_eigenvectors = (
+    os.environ.get("JAXMG_SYEVD_RETURN_EIGENVECTORS", "1") == "1"
+)
 
 # Choose the GPU allocator (vmm vs platform) before the backend is created.
 select_gpu_allocator(proc_id)
@@ -73,12 +76,16 @@ def run_case() -> None:
                 tile_size,
                 mesh=mesh,
                 matrix_specs=matrix_specs,
+                return_eigenvectors=return_eigenvectors,
                 pad=True,
             )
 
-        a_work, eigenvalues, vectors, status = eigensolve(
-            a_dev, tile_size=case.tile_size
-        )
+        outputs = eigensolve(a_dev, tile_size=case.tile_size)
+        if return_eigenvectors:
+            a_work, eigenvalues, vectors, status = outputs
+        else:
+            a_work, eigenvalues, status = outputs
+            vectors = None
         a_work.block_until_ready()
     else:
 
@@ -89,36 +96,52 @@ def run_case() -> None:
                 tile_size,
                 mesh=mesh,
                 matrix_specs=matrix_specs,
+                return_eigenvectors=return_eigenvectors,
                 return_status=True,
                 pad=True,
             )
 
-        eigenvalues, vectors, status = eigensolve(
-            a_dev, tile_size=case.tile_size
-        )
+        outputs = eigensolve(a_dev, tile_size=case.tile_size)
+        if return_eigenvectors:
+            eigenvalues, vectors, status = outputs
+        else:
+            eigenvalues, status = outputs
+            vectors = None
     eigenvalues.block_until_ready()
-    vectors.block_until_ready()
+    if vectors is not None:
+        vectors.block_until_ready()
     status.block_until_ready()
 
     status_words = native_status_words(status)
     assert status_words.size % _CUSOLVERMP_SYEVD_STATUS_SIZE == 0, status_words
     assert np.all(status_words[::_CUSOLVERMP_SYEVD_STATUS_SIZE] == 0), status_words
+    assert np.all(
+        status_words[20::_CUSOLVERMP_SYEVD_STATUS_SIZE]
+        == int(return_eigenvectors)
+    ), status_words
+    assert np.all(
+        status_words[27::_CUSOLVERMP_SYEVD_STATUS_SIZE]
+        == int(return_eigenvectors)
+    ), status_words
 
     assert_close_scaled(eigenvalues, expected_eigenvalues, atol=1e-3, rtol=1e-3)
 
-    a_host = np.asarray(a)
-    eigenvalues_host = global_array_to_numpy(eigenvalues)
-    vectors_host = global_array_to_numpy(vectors)
-    residual = np.linalg.norm(
-        a_host @ vectors_host - vectors_host * eigenvalues_host[None, :]
-    )
-    residual = residual / np.linalg.norm(a_host)
-    assert float(residual) < 5e-3
+    if vectors is not None:
+        a_host = np.asarray(a)
+        eigenvalues_host = global_array_to_numpy(eigenvalues)
+        vectors_host = global_array_to_numpy(vectors)
+        residual = np.linalg.norm(
+            a_host @ vectors_host - vectors_host * eigenvalues_host[None, :]
+        )
+        residual = residual / np.linalg.norm(a_host)
+        assert float(residual) < 5e-3
 
-    identity = np.eye(case.n, dtype=vectors_host.dtype)
-    orthogonality = np.linalg.norm(vectors_host.conj().T @ vectors_host - identity)
-    orthogonality = orthogonality / np.sqrt(case.n)
-    assert float(orthogonality) < 5e-3
+        identity = np.eye(case.n, dtype=vectors_host.dtype)
+        orthogonality = np.linalg.norm(
+            vectors_host.conj().T @ vectors_host - identity
+        )
+        orthogonality = orthogonality / np.sqrt(case.n)
+        assert float(orthogonality) < 5e-3
 
     emit(
         "MPTEST_RESULT",
@@ -128,6 +151,7 @@ def run_case() -> None:
             "dtype": dtype_name,
             "status": "ok",
             "interface": interface,
+            "return_eigenvectors": return_eigenvectors,
             "params": {
                 "n": case.n,
                 "tile_size": case.tile_size,

--- a/tests/mpmd/test_launch_syevd.py
+++ b/tests/mpmd/test_launch_syevd.py
@@ -42,6 +42,30 @@ def test_syevd_shardmap_ctx_two_gpu():
     )
 
 
+@pytest.mark.parametrize("dtype_name", DTYPES)
+def test_syevd_values_only_two_gpu(monkeypatch, dtype_name):
+    """Run the values-only native workflow on a two-GPU process grid."""
+    monkeypatch.setenv("JAXMG_SYEVD_RETURN_EIGENVECTORS", "0")
+    run_mpmd_test(
+        MP_TEST,
+        2,
+        "column_major_padding",
+        dtype_name,
+    )
+
+
+def test_syevd_values_only_shardmap_ctx_two_gpu(monkeypatch):
+    """Run caller-jitted values-only SYEVD through the context interface."""
+    monkeypatch.setenv("JAXMG_SYEVD_RETURN_EIGENVECTORS", "0")
+    run_mpmd_test(
+        MP_TEST,
+        2,
+        "column_major_padding",
+        "float32",
+        interface="context",
+    )
+
+
 @pytest.mark.slow
 @pytest.mark.parametrize("requested_procs", COMPREHENSIVE_PROCESS_COUNTS)
 @pytest.mark.parametrize("case_name", COMPREHENSIVE_CASES)


### PR DESCRIPTION
Updated cuSOLVERMp from 0.8.0 to 0.9.0.

cuSOLVERMp's version 0.9 replaces the hidden inconsistency in their docs where SYEVD really took the `compz` argument despite the docs describing `jobz`, the existing eigenvector path now uses `jobz='V'`.

This also adds a `return_eigenvectors` option to `syevd` and `syevd_shardmap_ctx`. It defaults to `True`, preserving the original functionality, while `False` selects `jobz='N'` and uses a separate FFI path that returns only the eigenvalues without allocating and redistributing a matrix-sized eigenvector output.
