### PR TITLE
Accept a single-axis mesh (NetKet-style meshes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ JAXMg connects JAX to NVIDIA's distributed
 [cuSOLVERMp](https://docs.nvidia.com/cuda/cusolvermp/) routines through a native
 C++/CUDA backend.
 
-Supply a JAX matrix sharded over a two-dimensional device mesh, and JAXMg
+Supply a JAX matrix sharded over a one- or two-axis device mesh, and JAXMg
 handles the local memory-layout conversion, redistribution into cuSOLVERMp's 2D
 block-cyclic layout, distributed numerical computation, and restoration of the
 result to its original JAX layout. The matrix data remains GPU-resident

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -4,7 +4,8 @@ This page highlights the primary public functions from the jaxmg package.
 Supported datatypes are `jax.numpy.float32`, `jax.numpy.float64`,
 `jax.numpy.complex64`, and `jax.numpy.complex128`.
 
-The routines accept ordinary JAX arrays sharded over a two-dimensional mesh.
+The routines accept ordinary JAX arrays sharded over a one- or two-axis device
+mesh.
 The fused C++/CUDA backend converts those arrays into cuSOLVERMp's column-major,
 2D block-cyclic layout and restores the JAX-facing layout before returning.
 

--- a/docs/examples/execution.md
+++ b/docs/examples/execution.md
@@ -79,6 +79,10 @@ axis, `pr`, identifies process rows; the second, `pc`, identifies process column
 Calling `jax.set_mesh(mesh)` makes this concrete mesh available while JAX traces
 the explicitly sharded computation.
 
+For performance, prefer a two-axis process grid where practical because it
+offers more parallelism during redistribution and solver execution. One-axis
+meshes remain useful when they already match the surrounding application.
+
 An existing one-axis mesh can be used directly. To shard matrix rows over its
 axis, use a rank-1 `PartitionSpec`:
 

--- a/docs/examples/execution.md
+++ b/docs/examples/execution.md
@@ -88,6 +88,10 @@ mesh = jax.make_mesh((8,), ("x",))
 matrix_specs = P("x", None)   # an 8 x 1 process grid; P("x") is equivalent
 ```
 
+The mesh passed to a solver does not have to be the one in context: each call
+enters its own mesh, so a program that keeps a different mesh set globally can
+call JAXMg without switching it.
+
 You can inspect the resultant process-rank mapping selected by JAX:
 
 ```python

--- a/docs/examples/execution.md
+++ b/docs/examples/execution.md
@@ -79,6 +79,15 @@ axis, `pr`, identifies process rows; the second, `pc`, identifies process column
 Calling `jax.set_mesh(mesh)` makes this concrete mesh available while JAX traces
 the explicitly sharded computation.
 
+A degenerate grid, where one matrix dimension is not distributed, is written
+with `None` in place of that mesh axis. A mesh with a single axis is then
+enough, which is convenient when the calling program already has one:
+
+```python
+mesh = jax.make_mesh((8,), ("x",))
+matrix_specs = P("x", None)   # an 8 x 1 process grid; P("x") is equivalent
+```
+
 You can inspect the resultant process-rank mapping selected by JAX:
 
 ```python

--- a/docs/examples/execution.md
+++ b/docs/examples/execution.md
@@ -59,9 +59,9 @@ Global devices: [CudaDevice(id=0), ..., CudaDevice(id=7)]
 
 ## 3. Construct the process grid
 
-JAXMg uses an ordinary two-dimensional JAX mesh. For eight ranks, valid grid
-shapes include $(8,1)$, $(4,2)$, $(2,4)$, and $(1,8)$. The following code
-constructs a $4\times2$ grid:
+JAXMg maps an ordinary one- or two-axis JAX mesh onto cuSOLVERMp's process grid.
+For eight ranks, valid grid shapes include $(8,1)$, $(4,2)$, $(2,4)$, and
+$(1,8)$. The following code constructs a $4\times2$ grid:
 
 ```python
 from jax.sharding import PartitionSpec as P
@@ -79,14 +79,16 @@ axis, `pr`, identifies process rows; the second, `pc`, identifies process column
 Calling `jax.set_mesh(mesh)` makes this concrete mesh available while JAX traces
 the explicitly sharded computation.
 
-A degenerate grid, where one matrix dimension is not distributed, is written
-with `None` in place of that mesh axis. A mesh with a single axis is then
-enough, which is convenient when the calling program already has one:
+An existing one-axis mesh can be used directly. To shard matrix rows over its
+axis, use a rank-1 `PartitionSpec`:
 
 ```python
-mesh = jax.make_mesh((8,), ("x",))
-matrix_specs = P("x", None)   # an 8 x 1 process grid; P("x") is equivalent
+single_axis_mesh = jax.make_mesh((8,), ("x",))
+single_axis_specs = P("x")
 ```
+
+For a rank-2 matrix, JAX treats `P("x")` as equivalent to `P("x", None)`.
+To shard columns instead, use `P(None, "x")`.
 
 The mesh passed to a solver does not have to be the one in context: each call
 enters its own mesh, so a program that keeps a different mesh set globally can
@@ -99,8 +101,8 @@ import numpy as np
 
 
 rank_grid = np.asarray(
-    [[device.process_index for device in row] for row in mesh.devices]
-)
+    [device.process_index for device in mesh.devices.flat]
+).reshape(mesh.devices.shape)
 if jax.process_index() == 0:
     print(rank_grid)
 ```
@@ -167,7 +169,7 @@ jax.set_mesh(mesh)
 ## 4. Shard the matrix and solve input
 
 `PartitionSpec` describes how each array dimension maps onto the process-grid
-axes. A matrix is normally sharded over both axes:
+axes. A matrix can be sharded over both axes:
 
 ```python
 import jax.numpy as jnp

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -9,8 +9,8 @@ Ready-to-run scripts are provided in the repository's
 ## 1. Configure Distributed Execution
 
 Start by initializing distributed JAX,
-assigning one GPU to each process, and constructing the two-dimensional device
-mesh used by the matrix.
+assigning one GPU to each process, and constructing the device mesh used by the
+matrix.
 
 [Configure distributed execution](execution.md)
 

--- a/docs/examples/lu_solve.md
+++ b/docs/examples/lu_solve.md
@@ -8,6 +8,8 @@ input/output aliasing, padding, and distributed execution.
 
 ## Common setup
 
+The following setup uses a one-axis device mesh with one Python process per GPU:
+
 ```python
 import jax
 
@@ -20,9 +22,9 @@ from jaxmg import lu_solve
 
 
 num_processes = jax.process_count()
-mesh = jax.make_mesh((num_processes, 1), ("pr", "pc"))
+mesh = jax.make_mesh((num_processes,), ("pr",))
 jax.set_mesh(mesh)
-matrix_specs = P("pr", "pc")
+matrix_specs = P("pr")
 a_sharding = NamedSharding(mesh, matrix_specs)
 b_sharding = NamedSharding(mesh, P("pr", None))
 

--- a/docs/examples/potrs.md
+++ b/docs/examples/potrs.md
@@ -22,7 +22,8 @@ factorization or a separate determinant calculation.
 
 ## Common setup
 
-The following setup uses a one-axis device mesh with one Python process per GPU:
+The following setup uses an even number of processes arranged as a two-axis
+device mesh, with one Python process per GPU:
 
 ```python
 import jax
@@ -36,9 +37,11 @@ from jaxmg import potrs
 
 
 num_processes = jax.process_count()
-mesh = jax.make_mesh((num_processes,), ("pr",))
+if num_processes % 2:
+    raise ValueError("This example requires an even number of processes.")
+mesh = jax.make_mesh((num_processes // 2, 2), ("pr", "pc"))
 jax.set_mesh(mesh)
-matrix_specs = P("pr")
+matrix_specs = P("pr", "pc")
 a_sharding = NamedSharding(mesh, matrix_specs)
 b_sharding = NamedSharding(mesh, P("pr", None))
 

--- a/docs/examples/potrs.md
+++ b/docs/examples/potrs.md
@@ -22,8 +22,7 @@ factorization or a separate determinant calculation.
 
 ## Common setup
 
-The following setup uses a degenerate two-dimensional process grid with one
-Python process per GPU:
+The following setup uses a one-axis device mesh with one Python process per GPU:
 
 ```python
 import jax
@@ -37,9 +36,9 @@ from jaxmg import potrs
 
 
 num_processes = jax.process_count()
-mesh = jax.make_mesh((num_processes, 1), ("pr", "pc"))
+mesh = jax.make_mesh((num_processes,), ("pr",))
 jax.set_mesh(mesh)
-matrix_specs = P("pr", "pc")
+matrix_specs = P("pr")
 a_sharding = NamedSharding(mesh, matrix_specs)
 b_sharding = NamedSharding(mesh, P("pr", None))
 

--- a/docs/examples/syevd.md
+++ b/docs/examples/syevd.md
@@ -8,7 +8,8 @@ input/output aliasing, padding, and distributed execution.
 
 ## Common setup
 
-The following setup uses a one-axis device mesh with one Python process per GPU:
+The following setup uses an even number of processes arranged as a two-axis
+device mesh, with one Python process per GPU:
 
 ```python
 import jax
@@ -22,9 +23,11 @@ from jaxmg import syevd
 
 
 num_processes = jax.process_count()
-mesh = jax.make_mesh((num_processes,), ("pr",))
+if num_processes % 2:
+    raise ValueError("This example requires an even number of processes.")
+mesh = jax.make_mesh((num_processes // 2, 2), ("pr", "pc"))
 jax.set_mesh(mesh)
-matrix_specs = P("pr")
+matrix_specs = P("pr", "pc")
 a_sharding = NamedSharding(mesh, matrix_specs)
 
 T_A = 64

--- a/docs/examples/syevd.md
+++ b/docs/examples/syevd.md
@@ -8,8 +8,7 @@ input/output aliasing, padding, and distributed execution.
 
 ## Common setup
 
-The following setup uses a degenerate two-dimensional process grid with one
-Python process per GPU:
+The following setup uses a one-axis device mesh with one Python process per GPU:
 
 ```python
 import jax
@@ -23,9 +22,9 @@ from jaxmg import syevd
 
 
 num_processes = jax.process_count()
-mesh = jax.make_mesh((num_processes, 1), ("pr", "pc"))
+mesh = jax.make_mesh((num_processes,), ("pr",))
 jax.set_mesh(mesh)
-matrix_specs = P("pr", "pc")
+matrix_specs = P("pr")
 a_sharding = NamedSharding(mesh, matrix_specs)
 
 T_A = 64

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ JAXMg connects JAX to NVIDIA's distributed
 [cuSOLVERMp](https://docs.nvidia.com/cuda/cusolvermp/) routines through a native
 C++/CUDA backend.
 
-Supply a JAX matrix sharded over a two-dimensional device mesh, and JAXMg
+Supply a JAX matrix sharded over a one- or two-axis device mesh, and JAXMg
 handles the local memory-layout conversion, redistribution into cuSOLVERMp's 2D
 block-cyclic layout, distributed numerical computation, and restoration of the
 result to its original JAX layout. The matrix data remains GPU-resident

--- a/docs/install.md
+++ b/docs/install.md
@@ -23,7 +23,7 @@ Documentation for JAXMg `0.0.9` is archived at
 built on NVIDIA's single-node [cuSolverMg](https://docs.nvidia.com/cuda/cusolver/index.html#using-the-cuSolverMg-api)
 API, so its interface differs substantially from this one: it provides `potri`
 and the `cyclic_1d` layout helpers, has no `lu_solve`, and distributes matrices
-over a 1D device mesh rather than a 2D process grid.
+with a 1D block-cyclic layout rather than the 2D block-cyclic layout used here.
 
 ## Supported systems
 

--- a/docs/technical_details/index.md
+++ b/docs/technical_details/index.md
@@ -1,6 +1,6 @@
 # Native workflow
 
-JAXMg accepts ordinary JAX arrays sharded over a two-dimensional device mesh.
+JAXMg accepts ordinary JAX arrays sharded over a one- or two-axis device mesh.
 However, cuSOLVERMp requires column-major local buffers distributed in a 2D
 block-cyclic layout. The native backend bridges these layouts inside one fused
 C++/CUDA FFI call:

--- a/docs/technical_details/memory_distribution.md
+++ b/docs/technical_details/memory_distribution.md
@@ -1,6 +1,6 @@
 # Memory distribution
 
-JAXMg accepts ordinary JAX arrays sharded over a two-dimensional device mesh.
+JAXMg accepts ordinary JAX arrays sharded over a one- or two-axis device mesh.
 However, cuSOLVERMp expects each local matrix buffer to use column-major memory
 and the global matrix to follow a 2D block-cyclic distribution. JAXMg bridges
 these layouts inside one fused C++/CUDA FFI call.
@@ -361,4 +361,3 @@ Native C++/CUDA is responsible for:
 |[src/cuda/cusolvermp_routines/cusolvermp_lu_solve.cc](https://github.com/flatironinstitute/jaxmg/tree/main/src/cuda/cusolvermp_routines/cusolvermp_lu_solve.cc) |
 |[src/cuda/cusolvermp_routines/cusolvermp_syevd.cc](https://github.com/flatironinstitute/jaxmg/tree/main/src/cuda/cusolvermp_routines/cusolvermp_syevd.cc) |
 |[src/cuda/cusolvermp_routines/cusolvermp_gesvd.cc](https://github.com/flatironinstitute/jaxmg/tree/main/src/cuda/cusolvermp_routines/cusolvermp_gesvd.cc) |
-

--- a/src/jaxmg/_cusolvermp_layout.py
+++ b/src/jaxmg/_cusolvermp_layout.py
@@ -15,6 +15,8 @@ C++/CUDA.  The helpers here only describe shapes and sharding to JAX.
 
 from __future__ import annotations
 
+import functools
+
 import jax.numpy as jnp
 import numpy as np
 import jax
@@ -92,6 +94,24 @@ def mesh_axis_size(mesh: Mesh, axis_name: str) -> int:
         return int(mesh.shape[axis_name])
     except KeyError as exc:
         raise ValueError(f"mesh does not contain axis {axis_name!r}.") from exc
+
+
+def use_abstract_mesh_decorator(mesh: Mesh):
+    """The decorated function is called within the context of ``use_abstract_mesh``.
+
+    Needed because ``jax.shard_map`` rejects a mesh that is not the context mesh,
+    so a caller keeping its own mesh in context could not call JAXMg at all.
+    """
+
+    def decorator(fn):
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            with jax.sharding.use_abstract_mesh(mesh.abstract_mesh):
+                return fn(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
 
 
 def validate_2d_matrix_specs(

--- a/src/jaxmg/_cusolvermp_layout.py
+++ b/src/jaxmg/_cusolvermp_layout.py
@@ -308,10 +308,26 @@ def place_rhs_for_native_work(
     )
 
 
+def infer_rhs_specs(rhs: Array, *, matrix_specs: P) -> P:
+    """Return the RHS sharding to restore after native redistribution.
+
+    Capture this specification before entering an internal ``jax.jit`` because
+    tracing on Auto mesh axes may no longer expose the input array's original
+    ``NamedSharding``.
+    """
+    sharding = getattr(rhs, "sharding", None)
+    if not isinstance(sharding, NamedSharding):
+        sharding = getattr(jax.typeof(rhs), "sharding", None)
+    if isinstance(sharding, NamedSharding):
+        return sharding.spec
+    row_axis, _ = matrix_specs._partitions
+    return P(row_axis, None)
+
+
 def restore_rhs_from_native_work(
     rhs: Array,
     *,
-    reference_rhs: Array,
+    rhs_specs: P,
     mesh: Mesh,
     matrix_specs: P,
 ) -> Array:
@@ -326,31 +342,22 @@ def restore_rhs_from_native_work(
 
     Args:
         rhs: Solved native work buffer before removal of routing columns.
-        reference_rhs: Original solve input whose sharding should be restored.
+        rhs_specs: Original solve-input sharding to restore.
         mesh: JAX mesh used by the matrix and solve input.
         matrix_specs: Matrix sharding used by the native work buffer.
 
     Returns:
-        The solved input restored to the original named sharding. If the
-        reference has no ``NamedSharding``, the row axis remains sharded and
-        the column axis is replicated.
+        The solved input restored to the original named sharding.
 
     Raises:
         ValueError: If the matrix axes are absent or use an unsupported mixture
             of mesh-axis modes.
     """
-    reference_sharding = getattr(jax.typeof(reference_rhs), "sharding", None)
-    if isinstance(reference_sharding, NamedSharding):
-        target_specs = reference_sharding.spec
-    else:
-        row_axis, _ = matrix_specs._partitions
-        target_specs = P(row_axis, None)
-
     return _place_for_matrix_axis_mode(
         rhs,
         mesh=mesh,
         matrix_specs=matrix_specs,
-        target_specs=target_specs,
+        target_specs=rhs_specs,
     )
 
 

--- a/src/jaxmg/_cusolvermp_layout.py
+++ b/src/jaxmg/_cusolvermp_layout.py
@@ -275,12 +275,12 @@ def place_rhs_for_native_work(
     mesh: Mesh,
     matrix_specs: P,
 ) -> Array:
-    """Place an RHS in the native backend's regular 2D work sharding.
+    """Place an RHS in the matrix's native work sharding.
 
     The public solvers accept a replicated RHS-column axis, for example
-    ``P('pr', None)`` for an ``N x 1`` solve input. The shard-local native
-    FFI instead receives a regular ``P('pr', 'pc')`` work buffer. JAX has two
-    different APIs for that placement depending on how the mesh was created:
+    ``P('pr', None)`` for an ``N x 1`` solve input. Before the shard-local FFI,
+    the RHS is placed in the matrix's work sharding. JAX has two different APIs
+    for that placement depending on how the mesh was created:
     ``jax.make_mesh`` creates explicit axes and requires ``jax.reshard``,
     while the conventional ``Mesh(...)`` constructor creates auto axes and
     requires ``with_sharding_constraint`` inside a compiled computation.
@@ -291,7 +291,7 @@ def place_rhs_for_native_work(
     Args:
         rhs: Solve input in its user-facing sharding.
         mesh: JAX mesh used by the matrix and native work buffers.
-        matrix_specs: Regular 2D matrix sharding required by the native FFI.
+        matrix_specs: Matrix sharding required by the native FFI.
 
     Returns:
         The solve input placed in ``NamedSharding(mesh, matrix_specs)``.
@@ -317,7 +317,7 @@ def restore_rhs_from_native_work(
 ) -> Array:
     """Restore a solved RHS to its user-facing sharding before shape slicing.
 
-    Native work buffers use the matrix's regular 2D sharding and may contain
+    Native work buffers use the matrix's sharding and may contain
     extra columns so every process column owns data. On explicit mesh axes,
     slicing those columns away while they remain partitioned can produce a
     dimension that is not divisible by the process-column count. Restore the
@@ -328,7 +328,7 @@ def restore_rhs_from_native_work(
         rhs: Solved native work buffer before removal of routing columns.
         reference_rhs: Original solve input whose sharding should be restored.
         mesh: JAX mesh used by the matrix and solve input.
-        matrix_specs: Regular 2D sharding used by the native work buffer.
+        matrix_specs: Matrix sharding used by the native work buffer.
 
     Returns:
         The solved input restored to the original named sharding. If the

--- a/src/jaxmg/_cusolvermp_layout.py
+++ b/src/jaxmg/_cusolvermp_layout.py
@@ -97,12 +97,15 @@ def mesh_axis_size(mesh: Mesh, axis_name: str) -> int:
 def validate_2d_matrix_specs(
     mesh: Mesh,
     matrix_specs: P,
-) -> tuple[str, str, ProcessGrid]:
+) -> tuple[str | None, str | None, ProcessGrid]:
     """Validate and describe a two-dimensional matrix sharding.
 
-    cuSOLVERMp requires both logical matrix dimensions to map to named JAX mesh
-    axes. The first ``PartitionSpec`` entry defines the process-row axis and the
-    second defines the process-column axis.
+    The first ``PartitionSpec`` entry defines the process-row axis and the
+    second defines the process-column axis. Either one may be ``None``, which
+    describes a degenerate ``P_r x 1`` or ``1 x P_c`` process grid: the
+    corresponding matrix dimension is then not distributed, and every process
+    owns it whole. That is the natural sharding for callers whose mesh has a
+    single axis, such as ``Mesh(jax.devices(), ('x',))`` with ``P('x', None)``.
 
     Args:
         mesh: JAX mesh used to shard the matrix.
@@ -110,26 +113,34 @@ def validate_2d_matrix_specs(
 
     Returns:
         ``(row_axis, col_axis, grid)``, where ``grid`` contains the extents of
-        the two selected mesh axes.
+        the selected mesh axes, and an axis left unsharded is reported as
+        ``None`` with an extent of one.
 
     Raises:
         TypeError: If ``matrix_specs`` is not a ``PartitionSpec``.
-        ValueError: If the specification is not rank two, either matrix
-            dimension is unsharded, or a referenced axis is absent.
+        ValueError: If the specification is not rank two, both matrix
+            dimensions are unsharded, or a referenced axis is absent.
     """
     if not isinstance(matrix_specs, P):
         raise TypeError("matrix_specs must be a PartitionSpec.")
     if len(matrix_specs._partitions) != 2:
         raise ValueError("matrix_specs must describe a rank-2 sharding.")
     row_axis, col_axis = matrix_specs._partitions
-    if not isinstance(row_axis, str) or not isinstance(col_axis, str):
+    if row_axis is None and col_axis is None:
         raise ValueError(
-            "cuSOLVERMp currently requires both matrix axes to be sharded by "
-            "named mesh axes, for example P('pr', 'pc')."
+            "cuSOLVERMp requires at least one matrix axis to be sharded by a "
+            "named mesh axis, but matrix_specs leaves both unsharded."
         )
+    for axis in (row_axis, col_axis):
+        if not (isinstance(axis, str) or axis is None):
+            raise ValueError(
+                "cuSOLVERMp requires each matrix axis to be sharded by a single "
+                "named mesh axis or left unsharded, for example P('pr', 'pc') "
+                "or P('pr', None)."
+            )
     grid = ProcessGrid(
-        process_rows=mesh_axis_size(mesh, row_axis),
-        process_cols=mesh_axis_size(mesh, col_axis),
+        process_rows=1 if row_axis is None else mesh_axis_size(mesh, row_axis),
+        process_cols=1 if col_axis is None else mesh_axis_size(mesh, col_axis),
     )
     return row_axis, col_axis, grid
 
@@ -218,7 +229,8 @@ def _place_for_matrix_axis_mode(
             axes do not share a supported Explicit or Auto mode.
     """
     axis_types = dict(zip(mesh.axis_names, mesh.axis_types))
-    matrix_axes = tuple(matrix_specs._partitions)
+    # Only axes actually mapped onto the mesh have a mode to agree on.
+    matrix_axes = tuple(x for x in matrix_specs._partitions if x is not None)
     try:
         matrix_axis_types = tuple(axis_types[axis] for axis in matrix_axes)
     except KeyError as exc:
@@ -385,8 +397,8 @@ def _device_rank_key(device) -> tuple[int, int, int]:
 def process_rank_map_from_mesh(
     mesh: Mesh,
     *,
-    row_axis: str,
-    col_axis: str,
+    row_axis: str | None,
+    col_axis: str | None,
     grid: ProcessGrid,
     caller: str,
 ) -> ProcessRankMap:
@@ -400,8 +412,10 @@ def process_rank_map_from_mesh(
 
     Args:
         mesh: JAX mesh containing the process-grid devices.
-        row_axis: Mesh axis mapped to cuSOLVERMp process rows.
-        col_axis: Mesh axis mapped to cuSOLVERMp process columns.
+        row_axis: Mesh axis mapped to cuSOLVERMp process rows, or ``None`` for a
+            degenerate ``1 x P_c`` grid.
+        col_axis: Mesh axis mapped to cuSOLVERMp process columns, or ``None``
+            for a degenerate ``P_r x 1`` grid.
         grid: Expected two-dimensional process-grid shape.
         caller: Routine name included in validation errors.
 
@@ -415,9 +429,10 @@ def process_rank_map_from_mesh(
             cuSOLVERMp's supported grid mappings.
     """
     axis_names = tuple(mesh.axis_names)
-    if row_axis not in axis_names or col_axis not in axis_names:
+    matrix_axes = tuple(axis for axis in (row_axis, col_axis) if axis is not None)
+    if any(axis not in axis_names for axis in matrix_axes):
         raise ValueError("matrix sharding axes must be present in the mesh.")
-    if row_axis == col_axis:
+    if row_axis is not None and row_axis == col_axis:
         raise ValueError("matrix row and column axes must be distinct.")
 
     devices = np.asarray(mesh.devices, dtype=object)
@@ -428,19 +443,21 @@ def process_rank_map_from_mesh(
     if devices.size != grid.num_processes:
         raise ValueError(
             f"{caller} currently expects the JAX mesh to contain exactly the "
-            "two axes used by the cuSOLVERMp process grid. Got "
+            "axes used by the cuSOLVERMp process grid. Got "
             f"{devices.size} mesh devices for a {grid.process_rows} x "
             f"{grid.process_cols} process grid."
         )
 
-    row_position = axis_names.index(row_axis)
-    col_position = axis_names.index(col_axis)
-    devices_by_matrix_axis = np.moveaxis(
-        devices,
-        (row_position, col_position),
-        (0, 1),
+    # A degenerate grid leaves one matrix dimension unsharded: the mesh has no
+    # axis for it, so neither array below carries that extent-one dimension.
+    positions = tuple(axis_names.index(axis) for axis in matrix_axes)
+    devices_by_matrix_axis = np.moveaxis(devices, positions, range(len(positions)))
+    grid_shape = (grid.process_rows, grid.process_cols)
+    expected_shape = tuple(
+        size
+        for axis, size in zip((row_axis, col_axis), grid_shape)
+        if axis is not None
     )
-    expected_shape = (grid.process_rows, grid.process_cols)
     if devices_by_matrix_axis.shape != expected_shape:
         raise ValueError(
             "mesh device grid does not match the matrix process-grid shape "
@@ -613,7 +630,8 @@ def infer_mesh_and_matrix_specs(
         in_specs: Alias for ``matrix_specs``.
 
     Returns:
-        The resolved ``(mesh, matrix_specs)`` pair.
+        The resolved ``(mesh, matrix_specs)`` pair, with a rank-1
+        specification padded to rank two.
 
     Raises:
         ValueError: If inference is required but ``a`` has no
@@ -621,22 +639,23 @@ def infer_mesh_and_matrix_specs(
         TypeError: If the supplied matrix specification has an invalid type.
     """
     matrix_specs = normalize_matrix_specs(matrix_specs, in_specs=in_specs)
-    if mesh is not None and matrix_specs is not None:
-        return mesh, matrix_specs
+    if mesh is None or matrix_specs is None:
+        sharding = getattr(a, "sharding", None)
+        if not isinstance(sharding, NamedSharding):
+            raise ValueError(
+                "cuSOLVERMp routine could not infer mesh/matrix_specs from A. "
+                "Shard A with jax.sharding.NamedSharding or pass mesh=... and "
+                "matrix_specs=..."
+            )
+        if mesh is None:
+            mesh = sharding.mesh
+        if matrix_specs is None:
+            matrix_specs = sharding.spec
 
-    sharding = getattr(a, "sharding", None)
-    if not isinstance(sharding, NamedSharding):
-        raise ValueError(
-            "cuSOLVERMp routine could not infer mesh/matrix_specs from A. "
-            "Shard A with jax.sharding.NamedSharding or pass mesh=... and "
-            "matrix_specs=..."
-        )
-
-    if mesh is None:
-        mesh = sharding.mesh
-    if matrix_specs is None:
-        matrix_specs = sharding.spec
-    return mesh, matrix_specs
+    # ``P('x')`` and ``P('x', None)`` describe the same layout of a 2D array;
+    # pad the short form so the rest of the layout code stays rank-2 throughout.
+    partitions = matrix_specs._partitions
+    return mesh, P(*partitions, *(None,) * (2 - len(partitions)))
 
 
 # -----------------------------------------------------------------------------
@@ -644,7 +663,9 @@ def infer_mesh_and_matrix_specs(
 # -----------------------------------------------------------------------------
 
 
-def status_specs(row_axis: str, col_axis: str, grid: ProcessGrid) -> P:
+def status_specs(
+    row_axis: str | None, col_axis: str | None, grid: ProcessGrid
+) -> P:
     """Choose the sharding for a per-rank native status vector.
 
     The status vector has one logical axis but must retain one distinct shard per

--- a/src/jaxmg/_gesvd.py
+++ b/src/jaxmg/_gesvd.py
@@ -59,15 +59,15 @@ def gesvd(
     disabled independently so JAX does not allocate or redistribute an output
     that the application does not require.
 
-    The input and every requested matrix output use the same two-dimensional
-    JAX mesh and ``PartitionSpec``. Their logical dimensions must therefore be
+    The input and every requested matrix output use the same JAX mesh and
+    ``PartitionSpec``. Their logical dimensions must therefore be
     divisible by the corresponding process-grid dimensions. Tile padding is
     applied separately to A, U, and Vh when their local dimensions are not
     divisible by ``T_A``.
 
     Args:
-        a (Array): A rank-2 real or complex matrix sharded over a two-dimensional
-            device mesh.
+        a (Array): A rank-2 real or complex matrix sharded over a one- or
+            two-axis device mesh.
         T_A (int): Square cuSOLVERMp tile width. GESVD supports rectangular
             matrices but requires equal row and column tile dimensions.
         mesh (Mesh, optional): JAX mesh used by ``jax.shard_map``. If omitted,
@@ -231,8 +231,8 @@ def gesvd_shardmap_ctx(
     allocations even when A is donated.
 
     Args:
-        a (Array): A rank-2 real or complex matrix sharded over a two-dimensional
-            device mesh.
+        a (Array): A rank-2 real or complex matrix sharded over a one- or
+            two-axis device mesh.
         T_A (int): Square cuSOLVERMp tile width.
         mesh (Mesh, optional): JAX mesh used by ``jax.shard_map``. If omitted,
             inferred from ``a.sharding.mesh``.

--- a/src/jaxmg/_gesvd.py
+++ b/src/jaxmg/_gesvd.py
@@ -23,6 +23,7 @@ from ._cusolvermp_layout import (
     _unpad_local_2d,
     cusolvermp_grid_mapping_attr,
     infer_mesh_and_matrix_specs,
+    use_abstract_mesh_decorator,
     process_rank_map_from_mesh,
     standard_grid_rank_map_attr,
     status_specs,
@@ -592,6 +593,7 @@ def _gesvd_pipeline(
         check_vma=False,
     )
 
+    @use_abstract_mesh_decorator(mesh)
     def impl(_a: Array):
         """Apply local padding, fused GESVD, and requested output slicing."""
         outputs = gesvd_shardmap(pad_a(_a))

--- a/src/jaxmg/_lu_solve.py
+++ b/src/jaxmg/_lu_solve.py
@@ -63,8 +63,8 @@ def lu_solve(
         tile size.
 
     Args:
-        a (Array): 2D, nonsingular input matrix. Expected to be sharded
-            across a 2D mesh with a matrix ``PartitionSpec`` such as
+        a (Array): 2D, nonsingular input matrix sharded over a one- or two-axis
+            device mesh, for example with ``P(<row_axis>)`` or
             ``P(<row_axis>, <col_axis>)``.
         b (Array): 1D or 2D solve input. A vector is treated as an
             ``N x 1`` matrix.
@@ -209,8 +209,8 @@ def lu_solve_shardmap_ctx(
     donate ``a`` into an ``A``-sized output.
 
     Args:
-        a (Array): 2D, nonsingular input matrix. Expected to be sharded
-            across a 2D mesh with a matrix ``PartitionSpec`` such as
+        a (Array): 2D, nonsingular input matrix sharded over a one- or two-axis
+            device mesh, for example with ``P(<row_axis>)`` or
             ``P(<row_axis>, <col_axis>)``.
         b (Array): 1D or 2D solve input. A vector is treated as an
             ``N x 1`` matrix.
@@ -471,9 +471,9 @@ def _lu_solve_pipeline(
             b_distribution = jnp.pad(_b, ((0, 0), (0, b_distribution_padding)))
         else:
             b_distribution = _b
-        # The public API permits a replicated RHS-column axis, such as
-        # P("pr", None). Native redistribution instead consumes a regular
-        # 2D work buffer before shard-local tile-capacity padding.
+        # The public API permits RHS sharding that differs from A, such as a
+        # replicated RHS-column axis. Native redistribution consumes the
+        # matrix work sharding before shard-local tile-capacity padding.
         b_distribution = place_rhs_for_native_work(
             b_distribution,
             mesh=mesh,

--- a/src/jaxmg/_lu_solve.py
+++ b/src/jaxmg/_lu_solve.py
@@ -22,6 +22,7 @@ from ._cusolvermp_layout import (
     _unpad_local_2d,
     cusolvermp_grid_mapping_attr,
     infer_mesh_and_matrix_specs,
+    use_abstract_mesh_decorator,
     place_rhs_for_native_work,
     process_rank_map_from_mesh,
     restore_rhs_from_native_work,
@@ -462,6 +463,7 @@ def _lu_solve_pipeline(
         check_vma=False,
     )
 
+    @use_abstract_mesh_decorator(mesh)
     def impl(_a: Array, _b: Array) -> tuple[Array, Array, Array]:
         """Run padding, fused native LU solve, and unpadding."""
         a_padded = pad_a(_a)

--- a/src/jaxmg/_lu_solve.py
+++ b/src/jaxmg/_lu_solve.py
@@ -22,6 +22,7 @@ from ._cusolvermp_layout import (
     _unpad_local_2d,
     cusolvermp_grid_mapping_attr,
     infer_mesh_and_matrix_specs,
+    infer_rhs_specs,
     use_abstract_mesh_decorator,
     place_rhs_for_native_work,
     process_rank_map_from_mesh,
@@ -125,6 +126,7 @@ def lu_solve(
         matrix_specs=matrix_specs,
         in_specs=in_specs,
     )
+    rhs_specs = infer_rhs_specs(b, matrix_specs=matrix_specs)
     row_axis, col_axis, grid = validate_2d_matrix_specs(mesh, matrix_specs)
     rank_map = process_rank_map_from_mesh(
         mesh,
@@ -175,6 +177,7 @@ def lu_solve(
         rank_map.cusolvermp_grid_mapping,
         a_padding,
         b_padding,
+        rhs_specs,
         n=a.shape[0],
         nrhs=nrhs,
         b_distribution_cols=b_distribution_cols,
@@ -254,6 +257,7 @@ def lu_solve_shardmap_ctx(
         matrix_specs=matrix_specs,
         in_specs=in_specs,
     )
+    rhs_specs = infer_rhs_specs(b, matrix_specs=matrix_specs)
     row_axis, col_axis, grid = validate_2d_matrix_specs(mesh, matrix_specs)
     rank_map = process_rank_map_from_mesh(
         mesh,
@@ -304,6 +308,7 @@ def lu_solve_shardmap_ctx(
         rank_map.cusolvermp_grid_mapping,
         a_padding,
         b_padding,
+        rhs_specs,
         n=a.shape[0],
         nrhs=nrhs,
         b_distribution_cols=b_distribution_cols,
@@ -384,6 +389,7 @@ def _lu_solve_pipeline(
     grid_mapping: int,
     a_padding: MatrixPadding2D,
     b_padding: MatrixPadding2D,
+    rhs_specs: P,
     *,
     n: int,
     nrhs: int,
@@ -486,7 +492,7 @@ def _lu_solve_pipeline(
         out = unpad_b(b_solved_padded)
         out = restore_rhs_from_native_work(
             out,
-            reference_rhs=_b,
+            rhs_specs=rhs_specs,
             mesh=mesh,
             matrix_specs=matrix_specs,
         )
@@ -505,6 +511,7 @@ def _lu_solve_compiled(
     grid_mapping: int,
     a_padding: MatrixPadding2D,
     b_padding: MatrixPadding2D,
+    rhs_specs: P,
     *,
     n: int,
     nrhs: int,
@@ -521,6 +528,7 @@ def _lu_solve_compiled(
         grid_mapping,
         a_padding,
         b_padding,
+        rhs_specs,
         n=n,
         nrhs=nrhs,
         b_distribution_cols=b_distribution_cols,

--- a/src/jaxmg/_potrs.py
+++ b/src/jaxmg/_potrs.py
@@ -22,6 +22,7 @@ from ._cusolvermp_layout import (
     _unpad_local_2d,
     cusolvermp_grid_mapping_attr,
     infer_mesh_and_matrix_specs,
+    infer_rhs_specs,
     use_abstract_mesh_decorator,
     place_rhs_for_native_work,
     process_rank_map_from_mesh,
@@ -128,6 +129,7 @@ def potrs(
         matrix_specs=matrix_specs,
         in_specs=in_specs,
     )
+    rhs_specs = infer_rhs_specs(b, matrix_specs=matrix_specs)
     row_axis, col_axis, grid = validate_2d_matrix_specs(mesh, matrix_specs)
     rank_map = process_rank_map_from_mesh(
         mesh,
@@ -178,6 +180,7 @@ def potrs(
         rank_map.cusolvermp_grid_mapping,
         a_padding,
         b_padding,
+        rhs_specs,
         n=a.shape[0],
         nrhs=nrhs,
         b_distribution_cols=b_distribution_cols,
@@ -293,6 +296,7 @@ def potrs_shardmap_ctx(
         matrix_specs=matrix_specs,
         in_specs=in_specs,
     )
+    rhs_specs = infer_rhs_specs(b, matrix_specs=matrix_specs)
     row_axis, col_axis, grid = validate_2d_matrix_specs(mesh, matrix_specs)
     rank_map = process_rank_map_from_mesh(
         mesh,
@@ -343,6 +347,7 @@ def potrs_shardmap_ctx(
         rank_map.cusolvermp_grid_mapping,
         a_padding,
         b_padding,
+        rhs_specs,
         n=a.shape[0],
         nrhs=nrhs,
         b_distribution_cols=b_distribution_cols,
@@ -459,6 +464,7 @@ def _potrs_pipeline(
     grid_mapping: int,
     a_padding: MatrixPadding2D,
     b_padding: MatrixPadding2D,
+    rhs_specs: P,
     *,
     n: int,
     nrhs: int,
@@ -602,7 +608,7 @@ def _potrs_pipeline(
         out = unpad_b(b_solved_padded)
         out = restore_rhs_from_native_work(
             out,
-            reference_rhs=_b,
+            rhs_specs=rhs_specs,
             mesh=mesh,
             matrix_specs=matrix_specs,
         )
@@ -623,6 +629,7 @@ def _potrs_compiled(
     grid_mapping: int,
     a_padding: MatrixPadding2D,
     b_padding: MatrixPadding2D,
+    rhs_specs: P,
     *,
     n: int,
     nrhs: int,
@@ -640,6 +647,7 @@ def _potrs_compiled(
         grid_mapping,
         a_padding,
         b_padding,
+        rhs_specs,
         n=n,
         nrhs=nrhs,
         b_distribution_cols=b_distribution_cols,

--- a/src/jaxmg/_potrs.py
+++ b/src/jaxmg/_potrs.py
@@ -64,9 +64,9 @@ def potrs(
         tile size.
 
     Args:
-        a (Array): 2D, symmetric positive-definite input matrix. Expected
-            to be sharded across a 2D mesh with a matrix ``PartitionSpec`` such
-            as ``P(<row_axis>, <col_axis>)``.
+        a (Array): 2D, symmetric positive-definite input matrix sharded over a
+            one- or two-axis device mesh, for example with
+            ``P(<row_axis>)`` or ``P(<row_axis>, <col_axis>)``.
         b (Array): 1D or 2D solve input. A vector is treated as an
             ``N x 1`` matrix.
         T_A (int): Square tile width used by cuSOLVERMp. Each local shard
@@ -229,9 +229,9 @@ def potrs_shardmap_ctx(
         tile size.
 
     Args:
-        a (Array): 2D, symmetric positive-definite input matrix. Expected
-            to be sharded across a 2D mesh with a matrix ``PartitionSpec`` such
-            as ``P(<row_axis>, <col_axis>)``.
+        a (Array): 2D, symmetric positive-definite input matrix sharded over a
+            one- or two-axis device mesh, for example with
+            ``P(<row_axis>)`` or ``P(<row_axis>, <col_axis>)``.
         b (Array): 1D or 2D solve input. A vector is treated as an
             ``N x 1`` matrix.
         T_A (int): Square tile width used by cuSOLVERMp. Each local shard
@@ -585,9 +585,9 @@ def _potrs_pipeline(
             b_distribution = jnp.pad(_b, ((0, 0), (0, b_distribution_padding)))
         else:
             b_distribution = _b
-        # The public API permits a replicated RHS-column axis, such as
-        # P("pr", None). Native redistribution instead consumes a regular
-        # 2D work buffer before shard-local tile-capacity padding.
+        # The public API permits RHS sharding that differs from A, such as a
+        # replicated RHS-column axis. Native redistribution consumes the
+        # matrix work sharding before shard-local tile-capacity padding.
         b_distribution = place_rhs_for_native_work(
             b_distribution,
             mesh=mesh,

--- a/src/jaxmg/_potrs.py
+++ b/src/jaxmg/_potrs.py
@@ -22,6 +22,7 @@ from ._cusolvermp_layout import (
     _unpad_local_2d,
     cusolvermp_grid_mapping_attr,
     infer_mesh_and_matrix_specs,
+    use_abstract_mesh_decorator,
     place_rhs_for_native_work,
     process_rank_map_from_mesh,
     restore_rhs_from_native_work,
@@ -576,6 +577,7 @@ def _potrs_pipeline(
         check_vma=False,
     )
 
+    @use_abstract_mesh_decorator(mesh)
     def impl(_a: Array, _b: Array):
         """Run padding, fused native POTRS, and unpadding as one compiled path."""
         a_padded = pad_a(_a)

--- a/src/jaxmg/_syevd.py
+++ b/src/jaxmg/_syevd.py
@@ -23,6 +23,7 @@ from ._cusolvermp_layout import (
     _unpad_local_2d,
     cusolvermp_grid_mapping_attr,
     infer_mesh_and_matrix_specs,
+    use_abstract_mesh_decorator,
     process_rank_map_from_mesh,
     standard_grid_rank_map_attr,
     status_specs,
@@ -524,6 +525,7 @@ def _syevd_pipeline(
         check_vma=False,
     )
 
+    @use_abstract_mesh_decorator(mesh)
     def impl(_a: Array):
         """Run padding, fused native SYEVD, and optional vector unpadding."""
         a_padded = pad_a(_a)

--- a/src/jaxmg/_syevd.py
+++ b/src/jaxmg/_syevd.py
@@ -65,8 +65,8 @@ def syevd(
         tile size.
 
     Args:
-        a (Array): A 2D symmetric/Hermitian matrix. Expected to be sharded
-            across a 2D mesh with a matrix ``PartitionSpec`` such as
+        a (Array): A 2D symmetric/Hermitian matrix sharded over a one- or
+            two-axis device mesh, for example with ``P(<row_axis>)`` or
             ``P(<row_axis>, <col_axis>)``.
         T_A (int): Square tile width used by cuSOLVERMp. Each local shard
             dimension must be a multiple of ``T_A`` after padding.
@@ -208,8 +208,8 @@ def syevd_shardmap_ctx(
         tile size.
 
     Args:
-        a (Array): A 2D symmetric/Hermitian matrix. Expected to be sharded
-            across a 2D mesh with a matrix ``PartitionSpec`` such as
+        a (Array): A 2D symmetric/Hermitian matrix sharded over a one- or
+            two-axis device mesh, for example with ``P(<row_axis>)`` or
             ``P(<row_axis>, <col_axis>)``.
         T_A (int): Square tile width used by cuSOLVERMp. Each local shard
             dimension must be a multiple of ``T_A`` after padding.

--- a/tests/cpu_only/test_gesvd_interface.py
+++ b/tests/cpu_only/test_gesvd_interface.py
@@ -23,6 +23,12 @@ def _one_rank_mesh() -> Mesh:
     return Mesh(devices, ("pr", "pc"))
 
 
+def _single_axis_mesh() -> Mesh:
+    """Return a one-axis mesh for row-sharded matrix interface tests."""
+    devices = np.asarray(jax.devices()[:1], dtype=object)
+    return Mesh(devices, ("pr",))
+
+
 def _install_fake_gesvd_backend(monkeypatch):
     """Replace native GESVD factories with shape-correct Python stand-ins."""
     captured = {}
@@ -131,6 +137,23 @@ def test_gesvd_can_append_native_status(monkeypatch):
     )
     assert singular_values.dtype == jnp.float32
     assert status.shape == (_CUSOLVERMP_GESVD_STATUS_SIZE,)
+
+
+def test_gesvd_accepts_rank_1_matrix_specs(monkeypatch):
+    """P('pr') is normalized to the equivalent P('pr', None)."""
+    captured = _install_fake_gesvd_backend(monkeypatch)
+
+    singular_values = gesvd(
+        jnp.ones((6, 4), dtype=jnp.float32),
+        2,
+        mesh=_single_axis_mesh(),
+        matrix_specs=P("pr"),
+        compute_u=False,
+        compute_vh=False,
+    )
+
+    assert singular_values.shape == (4,)
+    assert captured["args"][1] == P("pr", None)
 
 
 def test_gesvd_shardmap_ctx_exposes_work_and_selected_outputs(monkeypatch):

--- a/tests/cpu_only/test_lu_solve_interface.py
+++ b/tests/cpu_only/test_lu_solve_interface.py
@@ -260,6 +260,23 @@ def test_lu_solve_accepts_degenerate_column_grid(monkeypatch):
     assert (grid.process_rows, grid.process_cols) == (1, 1)
 
 
+def test_lu_solve_accepts_rank_1_matrix_specs(monkeypatch):
+    """P('pr') is normalized to the equivalent P('pr', None)."""
+    captured = _install_fake_lu_solve_backend(monkeypatch)
+    b = jnp.ones((4, 1), dtype=jnp.float32)
+
+    out = lu_solve(
+        jnp.eye(4, dtype=jnp.float32),
+        b,
+        2,
+        mesh=_single_axis_mesh(),
+        matrix_specs=P("pr"),
+    )
+
+    assert out.shape == b.shape
+    assert captured["args"][1] == P("pr", None)
+
+
 def test_lu_solve_rejects_fully_replicated_matrix_specs():
     with pytest.raises(ValueError, match="at least one matrix axis"):
         lu_solve(

--- a/tests/cpu_only/test_lu_solve_interface.py
+++ b/tests/cpu_only/test_lu_solve_interface.py
@@ -22,6 +22,12 @@ def _one_rank_mesh() -> Mesh:
     return Mesh(devices, ("pr", "pc"))
 
 
+def _single_axis_mesh() -> Mesh:
+    """Return a mesh with one axis, as used by callers that shard only rows."""
+    devices = np.asarray(jax.devices()[:1], dtype=object)
+    return Mesh(devices, ("pr",))
+
+
 def _install_fake_lu_solve_backend(monkeypatch):
     """Replace native backend entry points with a small Python stand-in."""
     captured = {}
@@ -236,14 +242,32 @@ def test_lu_solve_rejects_ambiguous_spec_arguments():
         )
 
 
-def test_lu_solve_rejects_1d_matrix_specs():
-    with pytest.raises(ValueError, match="both matrix axes"):
+def test_lu_solve_accepts_degenerate_column_grid(monkeypatch):
+    """A P_r x 1 grid leaves the matrix columns undistributed."""
+    captured = _install_fake_lu_solve_backend(monkeypatch)
+    b = jnp.ones((4, 1), dtype=jnp.float32)
+
+    out = lu_solve(
+        jnp.eye(4, dtype=jnp.float32),
+        b,
+        2,
+        mesh=_single_axis_mesh(),
+        matrix_specs=P("pr", None),
+    )
+
+    assert out.shape == b.shape
+    grid = captured["args"][3]
+    assert (grid.process_rows, grid.process_cols) == (1, 1)
+
+
+def test_lu_solve_rejects_fully_replicated_matrix_specs():
+    with pytest.raises(ValueError, match="at least one matrix axis"):
         lu_solve(
             jnp.eye(4),
             jnp.ones((4, 1)),
             2,
             mesh=_one_rank_mesh(),
-            matrix_specs=P("pr", None),
+            matrix_specs=P(None, None),
         )
 
 

--- a/tests/cpu_only/test_mesh_context.py
+++ b/tests/cpu_only/test_mesh_context.py
@@ -1,0 +1,71 @@
+import numpy as np
+import pytest
+
+import jax
+from jax.sharding import Mesh, PartitionSpec as P
+
+from jaxmg._cusolvermp_layout import use_abstract_mesh_decorator
+
+
+def _mesh(axis_name: str) -> Mesh:
+    devices = np.asarray(jax.devices()[:1], dtype=object)
+    return Mesh(devices, (axis_name,))
+
+
+def test_use_abstract_mesh_decorator_sets_and_restores_context():
+    mesh = _mesh("pr")
+    before = jax.sharding.get_abstract_mesh()
+
+    @use_abstract_mesh_decorator(mesh)
+    def body():
+        return jax.sharding.get_abstract_mesh()
+
+    assert body() == mesh.abstract_mesh
+    assert jax.sharding.get_abstract_mesh() == before
+
+
+def test_use_abstract_mesh_decorator_applies_inside_jit():
+    """Solvers are traced inside jax.jit, where set_mesh cannot be used."""
+    mesh = _mesh("pr")
+    seen = {}
+
+    @jax.jit
+    def f(x):
+        @use_abstract_mesh_decorator(mesh)
+        def body(x):
+            seen["mesh"] = jax.sharding.get_abstract_mesh()
+            return x + 1
+
+        return body(x)
+
+    f(jax.numpy.zeros((2,)))
+    assert seen["mesh"] == mesh.abstract_mesh
+
+
+def test_shard_map_runs_under_a_foreign_context_mesh():
+    """A caller with its own context mesh must not have to switch it themselves."""
+    mesh = _mesh("pr")
+    caller_mesh = Mesh(np.asarray(jax.devices()[:1], dtype=object), ("caller",))
+
+    @use_abstract_mesh_decorator(mesh)
+    def shard_mapped(x):
+        return jax.shard_map(
+            lambda block: block * 2,
+            mesh=mesh,
+            in_specs=P("pr"),
+            out_specs=P("pr"),
+            check_vma=False,
+        )(x)
+
+    x = jax.numpy.ones((4,))
+    with jax.sharding.use_abstract_mesh(caller_mesh.abstract_mesh):
+        np.testing.assert_allclose(np.asarray(shard_mapped(x)), 2.0)
+        # without the decorator, jax rejects the mismatched context mesh
+        with pytest.raises(ValueError, match="context mesh"):
+            jax.shard_map(
+                lambda block: block * 2,
+                mesh=mesh,
+                in_specs=P("pr"),
+                out_specs=P("pr"),
+                check_vma=False,
+            )(x)

--- a/tests/cpu_only/test_potrs_interface.py
+++ b/tests/cpu_only/test_potrs_interface.py
@@ -21,6 +21,12 @@ def _one_rank_mesh() -> Mesh:
     return Mesh(devices, ("pr", "pc"))
 
 
+def _single_axis_mesh() -> Mesh:
+    """Return a mesh with one axis, as used by callers that shard only rows."""
+    devices = np.asarray(jax.devices()[:1], dtype=object)
+    return Mesh(devices, ("pr",))
+
+
 def _install_fake_potrs_backend(monkeypatch):
     """Replace native backend entry points with a small Python stand-in."""
     captured = {}
@@ -301,14 +307,39 @@ def test_potrs_rejects_ambiguous_spec_arguments():
         )
 
 
-def test_potrs_rejects_1d_matrix_specs():
-    with pytest.raises(ValueError, match="both matrix axes"):
+def test_potrs_accepts_degenerate_column_grid(monkeypatch):
+    """A P_r x 1 grid leaves the matrix columns undistributed."""
+    captured = _install_fake_potrs_backend(monkeypatch)
+    a = jnp.eye(4, dtype=jnp.float32)
+    b = jnp.ones((4, 1), dtype=jnp.float32)
+
+    out = potrs(a, b, 2, mesh=_single_axis_mesh(), matrix_specs=P("pr", None))
+
+    assert out.shape == b.shape
+    grid = captured["args"][3]
+    assert (grid.process_rows, grid.process_cols) == (1, 1)
+
+
+def test_potrs_accepts_rank_1_matrix_specs(monkeypatch):
+    """P('pr') is the same layout as P('pr', None)."""
+    captured = _install_fake_potrs_backend(monkeypatch)
+    a = jnp.eye(4, dtype=jnp.float32)
+    b = jnp.ones((4, 1), dtype=jnp.float32)
+
+    out = potrs(a, b, 2, mesh=_single_axis_mesh(), matrix_specs=P("pr"))
+
+    assert out.shape == b.shape
+    assert captured["args"][1] == P("pr", None)
+
+
+def test_potrs_rejects_fully_replicated_matrix_specs():
+    with pytest.raises(ValueError, match="at least one matrix axis"):
         potrs(
             jnp.eye(4),
             jnp.ones((4, 1)),
             2,
             mesh=_one_rank_mesh(),
-            matrix_specs=P("pr", None),
+            matrix_specs=P(None, None),
         )
 
 

--- a/tests/cpu_only/test_syevd_interface.py
+++ b/tests/cpu_only/test_syevd_interface.py
@@ -21,6 +21,12 @@ def _one_rank_mesh() -> Mesh:
     return Mesh(devices, ("pr", "pc"))
 
 
+def _single_axis_mesh() -> Mesh:
+    """Return a mesh with one axis, as used by callers that shard only rows."""
+    devices = np.asarray(jax.devices()[:1], dtype=object)
+    return Mesh(devices, ("pr",))
+
+
 def _install_fake_syevd_backend(monkeypatch):
     """Replace native backend entry points with a small Python stand-in."""
     captured = {}
@@ -260,13 +266,44 @@ def test_syevd_rejects_ambiguous_spec_arguments():
         )
 
 
-def test_syevd_rejects_1d_matrix_specs():
-    with pytest.raises(ValueError, match="both matrix axes"):
+def test_syevd_accepts_degenerate_column_grid(monkeypatch):
+    """A P_r x 1 grid leaves the matrix columns undistributed."""
+    captured = _install_fake_syevd_backend(monkeypatch)
+
+    eigenvalues, vectors = syevd(
+        jnp.eye(4, dtype=jnp.float32),
+        2,
+        mesh=_single_axis_mesh(),
+        matrix_specs=P("pr", None),
+    )
+
+    assert eigenvalues.shape == (4,)
+    assert vectors.shape == (4, 4)
+    grid = captured["args"][3]
+    assert (grid.process_rows, grid.process_cols) == (1, 1)
+
+
+def test_syevd_accepts_rank_1_matrix_specs(monkeypatch):
+    """P('pr') is the same layout as P('pr', None)."""
+    captured = _install_fake_syevd_backend(monkeypatch)
+
+    syevd(
+        jnp.eye(4, dtype=jnp.float32),
+        2,
+        mesh=_single_axis_mesh(),
+        matrix_specs=P("pr"),
+    )
+
+    assert captured["args"][1] == P("pr", None)
+
+
+def test_syevd_rejects_fully_replicated_matrix_specs():
+    with pytest.raises(ValueError, match="at least one matrix axis"):
         syevd(
             jnp.eye(4),
             2,
             mesh=_one_rank_mesh(),
-            matrix_specs=P("pr", None),
+            matrix_specs=P(None, None),
         )
 
 

--- a/tests/gpu/cusolvermp_case_utils.py
+++ b/tests/gpu/cusolvermp_case_utils.py
@@ -184,6 +184,22 @@ def solver_case(case_name: str, num_processes: int, *, routine: str) -> SolverCa
         rows, cols, tile, padded, nrhs = num_processes, 1, 64, False, 1
         grid_order = "row_major"
         rhs_mode = "matrix_row_sharded"
+    elif case_name == "single_axis_row_vector":
+        if not has_rhs:
+            raise ValueError(
+                "single_axis_row_vector is only meaningful for solve routines"
+            )
+        rows, cols, tile, padded, nrhs = num_processes, 1, 64, False, 1
+        grid_order = "row_major"
+        rhs_mode = "vector_row_sharded"
+    elif case_name == "single_axis_column_rhs":
+        if not has_rhs:
+            raise ValueError(
+                "single_axis_column_rhs is only meaningful for solve routines"
+            )
+        rows, cols, tile, padded, nrhs = 1, num_processes, 64, False, 1
+        grid_order = "row_major"
+        rhs_mode = "matrix_replicated"
     else:
         raise ValueError(f"unknown GPU solver case {case_name!r}")
 

--- a/tests/gpu/run_potrs.py
+++ b/tests/gpu/run_potrs.py
@@ -111,7 +111,6 @@ def run_case() -> None:
         a_work, out, status = solve(a_dev, b_dev, tile_size=case.tile_size)
         a_work.block_until_ready()
     else:
-        @partial(jax.jit, static_argnames=("tile_size",))
         def solve(_a, _b, *, tile_size):
             if single_axis:
                 return potrs(
@@ -132,6 +131,10 @@ def run_case() -> None:
                 return_logdet=return_logdet,
                 pad=True,
             )
+
+        # Keep concrete sharding available for the public API's mesh inference.
+        if not single_axis:
+            solve = jax.jit(solve, static_argnames=("tile_size",))
 
         if case_name == "single_axis_row_vector":
             caller_mesh = Mesh(

--- a/tests/gpu/run_potrs.py
+++ b/tests/gpu/run_potrs.py
@@ -71,6 +71,8 @@ def run_case() -> None:
     b = make_rhs(case.n, case.nrhs, dtype)
     if case.rhs_mode in ("vector_replicated", "vector_row_sharded"):
         b = b[:, 0]
+    a_host = np.asarray(a)
+    b_host = np.asarray(b)
     expected = jnp.linalg.solve(a, b)
 
     a_dev = jax.device_put(a, NamedSharding(mesh, matrix_specs))
@@ -160,8 +162,6 @@ def run_case() -> None:
         assert out.sharding.is_equivalent_to(expected_rhs_sharding, out.ndim)
 
     out_host = global_array_to_numpy(out)
-    a_host = np.asarray(a)
-    b_host = np.asarray(b)
     residual = np.linalg.norm(a_host @ out_host - b_host) / np.linalg.norm(b_host)
     assert float(residual) < 1e-3
     if return_logdet:

--- a/tests/gpu/run_potrs.py
+++ b/tests/gpu/run_potrs.py
@@ -10,7 +10,7 @@ if not jax.config.jax_enable_x64:
 import jax.numpy as jnp
 import numpy as np
 from jax.experimental import multihost_utils
-from jax.sharding import NamedSharding, PartitionSpec as P
+from jax.sharding import Mesh, NamedSharding, PartitionSpec as P
 
 from cusolvermp_case_utils import (
     assert_close_scaled,
@@ -54,18 +54,30 @@ def run_case() -> None:
     """Run one rank-per-GPU POTRS case and emit parser-friendly results."""
     dtype = dtype_from_name(dtype_name)
     case = solver_case(case_name, num_procs, routine="potrs")
-    mesh = make_process_mesh(case)
-    matrix_specs = P("pr", "pc")
+    single_axis = case_name in {
+        "single_axis_row_vector",
+        "single_axis_column_rhs",
+    }
+    if single_axis:
+        mesh = Mesh(np.asarray(jax.devices(), dtype=object), ("x",))
+        matrix_specs = (
+            P("x") if case_name == "single_axis_row_vector" else P(None, "x")
+        )
+    else:
+        mesh = make_process_mesh(case)
+        matrix_specs = P("pr", "pc")
 
     a = make_hermitian_positive_definite(case.n, dtype, seed=1234)
     b = make_rhs(case.n, case.nrhs, dtype)
-    if case.rhs_mode == "vector_replicated":
+    if case.rhs_mode in ("vector_replicated", "vector_row_sharded"):
         b = b[:, 0]
     expected = jnp.linalg.solve(a, b)
 
     a_dev = jax.device_put(a, NamedSharding(mesh, matrix_specs))
     if case.rhs_mode == "vector_replicated":
         rhs_specs = P(None)
+    elif case.rhs_mode == "vector_row_sharded":
+        rhs_specs = P("x")
     elif case.rhs_mode == "matrix_replicated":
         rhs_specs = P(None, None)
     elif case.rhs_mode == "matrix_row_sharded":
@@ -75,6 +87,7 @@ def run_case() -> None:
     else:
         raise ValueError(f"unknown RHS placement mode {case.rhs_mode!r}")
     b_dev = jax.device_put(b, NamedSharding(mesh, rhs_specs))
+    expected_rhs_sharding = b_dev.sharding
 
     if interface == "context":
         if return_logdet:
@@ -100,6 +113,15 @@ def run_case() -> None:
     else:
         @partial(jax.jit, static_argnames=("tile_size",))
         def solve(_a, _b, *, tile_size):
+            if single_axis:
+                return potrs(
+                    _a,
+                    _b,
+                    tile_size,
+                    return_status=True,
+                    return_logdet=return_logdet,
+                    pad=True,
+                )
             return potrs(
                 _a,
                 _b,
@@ -111,7 +133,14 @@ def run_case() -> None:
                 pad=True,
             )
 
-        result = solve(a_dev, b_dev, tile_size=case.tile_size)
+        if case_name == "single_axis_row_vector":
+            caller_mesh = Mesh(
+                np.asarray(jax.devices(), dtype=object), ("caller",)
+            )
+            with jax.sharding.use_abstract_mesh(caller_mesh.abstract_mesh):
+                result = solve(a_dev, b_dev, tile_size=case.tile_size)
+        else:
+            result = solve(a_dev, b_dev, tile_size=case.tile_size)
         if return_logdet:
             out, logdet, status = result
             logdet.block_until_ready()
@@ -124,6 +153,8 @@ def run_case() -> None:
     assert status_words.size % _CUSOLVERMP_POTRS_STATUS_SIZE == 0, status_words
     assert np.all(status_words[::_CUSOLVERMP_POTRS_STATUS_SIZE] == 0), status_words
     assert_close_scaled(out, expected)
+    if single_axis:
+        assert out.sharding.is_equivalent_to(expected_rhs_sharding, out.ndim)
 
     out_host = global_array_to_numpy(out)
     a_host = np.asarray(a)

--- a/tests/gpu/test_potrs.py
+++ b/tests/gpu/test_potrs.py
@@ -44,6 +44,7 @@ LOGDET_CASES = (
     pytest.param(4, "column_major_padding", marks=pytest.mark.multi_gpu),
     pytest.param(4, "column_grid_padding", marks=pytest.mark.multi_gpu),
 )
+SINGLE_AXIS_CASES = ("single_axis_row_vector", "single_axis_column_rhs")
 
 
 @pytest.mark.parametrize("requested_procs,case_name", SMOKE_CASES)
@@ -78,6 +79,13 @@ def test_potrs_shardmap_ctx_two_gpu():
         "float32",
         interface="context",
     )
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.parametrize("case_name", SINGLE_AXIS_CASES)
+def test_potrs_single_axis_mesh(case_name):
+    """Validate both orientations of a one-axis mesh on two GPUs."""
+    run_gpu_test(GPU_TEST, 2, case_name, "float32")
 
 
 @pytest.mark.slow


### PR DESCRIPTION
(This is a spinoff from getting jaxmg 1.0 to work in netket https://github.com/netket/netket/pull/2265 . FYI: All code was 90% written by claude, but I steered it heavily to write what I wanted, clean it up and make it more understable and follow a design I think it's reasonable)

Jax documentation explicitly state (see https://docs.jax.dev/en/latest/parallel.html ) that `None` in a `PartitionSpec` means that dimension is not sharded, and that "trailing `None` placeholders can be omitted, so that P('X', None) == P('X')".
This is heavily used by netket, for example, which follows this convention heavily in all its code.

However jaxmg requires that this extra dimension be explicitly specified in the mesh. Due to how shard map works, a non trivial amount of code is required to be able to use jamg when all arrays/matrices are specified with a rank-1 mesh.
While I can put this code in netket, I think that jaxmg itself is the better place to support rank-1 meshes and basically treat meshes like (Nr) -> (Nr, 1).

This PR essentially implements this. 

Basically what this PR does is that we call cuda from the context of 'use_abstract_mesh' so that we swap the abstract mesh to always be rank 2 . We do this by decorating those calls with 'use_abstract_mesh_decorator'.

There's a fair bit of logic change in the 'validate_2d_matrix_specs' to support the new setups. Basically the new things we support are:
 - P('S') , remapped to P('S', 1)
 - P('S', None) remapped to P(S, 1)
 - P(None, S) remapped to P(1, S)

What do you think?
I tested the PR on 2 H100 nodes and it passed tests.