### PR TITLE
Support for JAX 0.11.x

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -2,7 +2,7 @@ name: build-wheels (reusable)
 
 # Reusable workflow: build the CUDA 12 and CUDA 13
 # libjaxmg_xla_comm_backend.so libraries against @xla in the JAX CI container
-# (natively, no QEMU), then package both into cp3.11-cp3.14 manylinux wheels.
+# (natively, no QEMU), then package both into cp3.12-cp3.14 manylinux wheels.
 # Parameterized by arch so the same logic serves x86_64 and aarch64.
 #
 # Build-only: no GPU is available on GitHub runners, so wheels are packaged and
@@ -24,7 +24,7 @@ on:
         required: true
         type: string
       package_image:
-        description: 'manylinux image (ships cp3.11-3.14 + auditwheel) for packaging'
+        description: 'manylinux image (ships cp3.12-3.14 + auditwheel) for packaging'
         required: true
         type: string
       manylinux_plat:
@@ -133,7 +133,7 @@ jobs:
       fail-fast: false
       matrix:
         # <pip tag> == /opt/python/<cpython dir> in the manylinux image
-        python: ['cp311-cp311', 'cp312-cp312', 'cp313-cp313', 'cp314-cp314']
+        python: ['cp312-cp312', 'cp313-cp313', 'cp314-cp314']
     steps:
       - name: Checkout jaxmg
         uses: actions/checkout@v4

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   JAX_GIT_REPOSITORY: https://github.com/jax-ml/jax.git
-  JAX_GIT_TAG: jax-v0.11.1
+  JAX_GIT_TAG: jax-v0.11.0
 
 jobs:
   compile:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -66,6 +66,7 @@ jobs:
           CUDA_MAJOR: ${{ matrix.cuda_major }}
           CUDA_ARCHS: ${{ matrix.cuda_archs }}
           CUSOLVERMP: ${{ matrix.cusolvermp }}
+          JAXCI_HERMETIC_PYTHON_VERSION: '3.12'
         run: |
           set -euxo pipefail
           WS="$(pwd)"

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   JAX_GIT_REPOSITORY: https://github.com/jax-ml/jax.git
-  JAX_GIT_TAG: jax-v0.10.1
+  JAX_GIT_TAG: jax-v0.11.1
 
 jobs:
   compile:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install docs dependencies
         run: |
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install docs dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install docs dependencies
         run: |

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -96,7 +96,7 @@ PY
         }
       }
 
-      def pyVersions = ['3.11', '3.12', '3.13', '3.14']
+      def pyVersions = ['3.12', '3.13', '3.14']
       for (p in pyVersions) {
         stage("Test py${p}") {
           withEnv(["PYV=${p}"]) {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ silently replace the documentation for a released wheel.
 
 ## Updating JAX or CUDA
 
-JAXMg pins `jax==0.11.1` and builds against its matching internal XLA revision.
+JAXMg pins `jax==0.11.0` and builds against its matching internal XLA revision.
 Updating JAX therefore requires auditing the `@xla` targets, updating the JAX
 source tag and dependencies, and rebuilding both CUDA backends on both
 architectures.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ silently replace the documentation for a released wheel.
 
 ## Updating JAX or CUDA
 
-JAXMg pins `jax==0.10.1` and builds against its matching internal XLA revision.
+JAXMg pins `jax==0.11.1` and builds against its matching internal XLA revision.
 Updating JAX therefore requires auditing the `@xla` targets, updating the JAX
 source tag and dependencies, and rebuilding both CUDA backends on both
 architectures.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ The release build and GPU tests run on separate systems:
 
 1. **GitHub Actions builds** CUDA 12 and CUDA 13 backends for `x86_64` and
    `aarch64`.
-2. **GitHub Actions packages** Python 3.11–3.14 `manylinux_2_28` wheels and
+2. **GitHub Actions packages** Python 3.12–3.14 `manylinux_2_28` wheels and
    checks their metadata and native libraries.
 3. **Jenkins downloads those wheels** and installs the normal
    `jaxmg[cuda12]` dependency path.

--- a/docs/technical_details/building_from_source.md
+++ b/docs/technical_details/building_from_source.md
@@ -14,7 +14,7 @@ matching JAX source tree; they are not distributed as a standalone library.
 The build therefore combines:
 
 - the JAXMg C++/CUDA sources;
-- the JAX `0.10.1` checkout and its pinned XLA revision;
+- the JAX `0.11.0` checkout and its pinned XLA revision;
 - the selected CUDA and cuSOLVERMp dependencies.
 
 The result is `libjaxmg_xla_comm_backend.so`, installed under
@@ -52,7 +52,7 @@ sm_80,sm_90,sm_120,compute_90
 Clone the JAX version pinned by JAXMg and start its CI container:
 
 ```bash
-git clone --branch jax-v0.10.1 https://github.com/jax-ml/jax.git
+git clone --branch jax-v0.11.0 https://github.com/jax-ml/jax.git
 cd jax
 ./ci/utilities/run_docker_container.sh
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "jax>=0.10.1; sys_platform == 'linux'",
 ]
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
     "multi-GPU",
 ]
 dependencies = [
-    "jax==0.10.1; sys_platform == 'linux'",
+    "jax>=0.10.1; sys_platform == 'linux'",
 ]
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
     "multi-GPU",
 ]
 dependencies = [
-    "jax~=0.11.0; sys_platform == 'linux'",
+    "jax==0.11.0; sys_platform == 'linux'",
 ]
 readme = "README.md"
 requires-python = ">=3.12"
@@ -60,7 +60,7 @@ docs = [
 
 dev = [
     "matplotlib>=3.10.3",
-    "jax[cuda12]~=0.11.0",
+    "jax[cuda12]==0.11.0",
     "nvidia-cusolvermp-cu12==0.9.0.6427",
     "pytest==8.2.1",
     "mkdocs==1.6.1",
@@ -72,21 +72,21 @@ dev = [
 ]
 
 cuda12 = [
-    "jax[cuda12]~=0.11.0",
+    "jax[cuda12]==0.11.0",
     "nvidia-cusolvermp-cu12==0.9.0.6427",
 ]
 
 cuda13 = [
-    "jax[cuda13]~=0.11.0",
+    "jax[cuda13]==0.11.0",
     "nvidia-cusolvermp-cu13==0.9.0.6427",
 ]
 
 cuda12-local = [
-    "jax[cuda12-local]~=0.11.0",
+    "jax[cuda12-local]==0.11.0",
     "nvidia-cusolvermp-cu12==0.9.0.6427",
 ]
 
 cuda13-local = [
-    "jax[cuda13-local]~=0.11.0",
+    "jax[cuda13-local]==0.11.0",
     "nvidia-cusolvermp-cu13==0.9.0.6427",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
     "multi-GPU",
 ]
 dependencies = [
-    "jax>=0.10.1; sys_platform == 'linux'",
+    "jax~=0.11.0; sys_platform == 'linux'",
 ]
 readme = "README.md"
 requires-python = ">=3.12"
@@ -72,21 +72,21 @@ dev = [
 ]
 
 cuda12 = [
-    "jax[cuda12]>=0.10.1",
+    "jax[cuda12]~=0.11.0",
     "nvidia-cusolvermp-cu12==0.9.0.6427",
 ]
 
 cuda13 = [
-    "jax[cuda13]>=0.10.1",
+    "jax[cuda13]~=0.11.0",
     "nvidia-cusolvermp-cu13==0.9.0.6427",
 ]
 
 cuda12-local = [
-    "jax[cuda12-local]>=0.10.1",
+    "jax[cuda12-local]~=0.11.0",
     "nvidia-cusolvermp-cu12==0.9.0.6427",
 ]
 
 cuda13-local = [
-    "jax[cuda13-local]>=0.10.1",
+    "jax[cuda13-local]~=0.11.0",
     "nvidia-cusolvermp-cu13==0.9.0.6427",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ docs = [
 
 dev = [
     "matplotlib>=3.10.3",
-    "jax[cuda12]==0.10.1",
+    "jax[cuda12]==0.11.1",
     "nvidia-cusolvermp-cu12==0.9.0.6427",
     "pytest==8.2.1",
     "mkdocs==1.6.1",
@@ -72,21 +72,21 @@ dev = [
 ]
 
 cuda12 = [
-    "jax[cuda12]==0.10.1",
-    "nvidia-cusolvermp-cu12==0.9.0.6427",
+    "jax[cuda12]>=0.10.1",
+    "nvidia-cusolvermp-cu12>=0.9.0.6427",
 ]
 
 cuda13 = [
-    "jax[cuda13]==0.10.1",
-    "nvidia-cusolvermp-cu13==0.9.0.6427",
+    "jax[cuda13]>=0.10.1",
+    "nvidia-cusolvermp-cu13>=0.9.0.6427",
 ]
 
 cuda12-local = [
-    "jax[cuda12-local]==0.10.1",
-    "nvidia-cusolvermp-cu12==0.9.0.6427",
+    "jax[cuda12-local]>=0.10.1",
+    "nvidia-cusolvermp-cu12>=0.9.0.6427",
 ]
 
 cuda13-local = [
-    "jax[cuda13-local]==0.10.1",
-    "nvidia-cusolvermp-cu13==0.9.0.6427",
+    "jax[cuda13-local]>=0.10.1",
+    "nvidia-cusolvermp-cu13>=0.9.0.6427",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ docs = [
 
 dev = [
     "matplotlib>=3.10.3",
-    "jax[cuda12]~=0.11.1",
+    "jax[cuda12]~=0.11.0",
     "nvidia-cusolvermp-cu12==0.9.0.6427",
     "pytest==8.2.1",
     "mkdocs==1.6.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ docs = [
 
 dev = [
     "matplotlib>=3.10.3",
-    "jax[cuda12]==0.11.1",
+    "jax[cuda12]~=0.11.1",
     "nvidia-cusolvermp-cu12==0.9.0.6427",
     "pytest==8.2.1",
     "mkdocs==1.6.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,20 +73,20 @@ dev = [
 
 cuda12 = [
     "jax[cuda12]>=0.10.1",
-    "nvidia-cusolvermp-cu12>=0.9.0.6427",
+    "nvidia-cusolvermp-cu12==0.9.0.6427",
 ]
 
 cuda13 = [
     "jax[cuda13]>=0.10.1",
-    "nvidia-cusolvermp-cu13>=0.9.0.6427",
+    "nvidia-cusolvermp-cu13==0.9.0.6427",
 ]
 
 cuda12-local = [
     "jax[cuda12-local]>=0.10.1",
-    "nvidia-cusolvermp-cu12>=0.9.0.6427",
+    "nvidia-cusolvermp-cu12==0.9.0.6427",
 ]
 
 cuda13-local = [
     "jax[cuda13-local]>=0.10.1",
-    "nvidia-cusolvermp-cu13>=0.9.0.6427",
+    "nvidia-cusolvermp-cu13==0.9.0.6427",
 ]

--- a/src/cuda/cusolvermp_routines/cusolvermp_gesvd.cc
+++ b/src/cuda/cusolvermp_routines/cusolvermp_gesvd.cc
@@ -846,7 +846,7 @@ absl::Status XlaCusolverMpGesvdPrepare(
 
 // Executes GESVD with both left and right singular vectors.
 absl::Status XlaCusolverMpGesvdUvDispatch(
-    se::Stream* stream, se::Stream* comm_stream, cudaStream_t cuda_stream,
+    se::Stream* stream, cudaStream_t cuda_stream,
     int64_t process_rows, int64_t process_cols, int64_t m, int64_t n,
     int64_t tile_size, int64_t grid_mapping, int64_t full_matrices,
     absl::Span<const int64_t> rank_map, ffi::AnyBuffer a,
@@ -859,7 +859,8 @@ absl::Status XlaCusolverMpGesvdUvDispatch(
   ffi::AnyBuffer u_buffer = *u;
   ffi::AnyBuffer vh_buffer = *vh;
   return RunCusolverMpGesvdDispatch(
-      stream, comm_stream, cuda_stream, process_rows, process_cols, m, n,
+      stream, /*comm_stream=*/nullptr, cuda_stream, process_rows, process_cols,
+      m, n,
       tile_size, grid_mapping, full_matrices, rank_map, a, singular_values,
       work, &u_buffer, &vh_buffer, /*compute_u=*/true, /*compute_vh=*/true,
       status, collective_params, collective_cliques);
@@ -867,7 +868,7 @@ absl::Status XlaCusolverMpGesvdUvDispatch(
 
 // Executes GESVD with left singular vectors only.
 absl::Status XlaCusolverMpGesvdUDispatch(
-    se::Stream* stream, se::Stream* comm_stream, cudaStream_t cuda_stream,
+    se::Stream* stream, cudaStream_t cuda_stream,
     int64_t process_rows, int64_t process_cols, int64_t m, int64_t n,
     int64_t tile_size, int64_t grid_mapping, int64_t full_matrices,
     absl::Span<const int64_t> rank_map, ffi::AnyBuffer a,
@@ -878,7 +879,8 @@ absl::Status XlaCusolverMpGesvdUDispatch(
     const CollectiveCliques* collective_cliques) {
   ffi::AnyBuffer u_buffer = *u;
   return RunCusolverMpGesvdDispatch(
-      stream, comm_stream, cuda_stream, process_rows, process_cols, m, n,
+      stream, /*comm_stream=*/nullptr, cuda_stream, process_rows, process_cols,
+      m, n,
       tile_size, grid_mapping, full_matrices, rank_map, a, singular_values,
       work, &u_buffer, /*vh=*/nullptr, /*compute_u=*/true,
       /*compute_vh=*/false, status, collective_params, collective_cliques);
@@ -886,7 +888,7 @@ absl::Status XlaCusolverMpGesvdUDispatch(
 
 // Executes GESVD with right singular vectors only.
 absl::Status XlaCusolverMpGesvdVhDispatch(
-    se::Stream* stream, se::Stream* comm_stream, cudaStream_t cuda_stream,
+    se::Stream* stream, cudaStream_t cuda_stream,
     int64_t process_rows, int64_t process_cols, int64_t m, int64_t n,
     int64_t tile_size, int64_t grid_mapping, int64_t full_matrices,
     absl::Span<const int64_t> rank_map, ffi::AnyBuffer a,
@@ -897,7 +899,8 @@ absl::Status XlaCusolverMpGesvdVhDispatch(
     const CollectiveCliques* collective_cliques) {
   ffi::AnyBuffer vh_buffer = *vh;
   return RunCusolverMpGesvdDispatch(
-      stream, comm_stream, cuda_stream, process_rows, process_cols, m, n,
+      stream, /*comm_stream=*/nullptr, cuda_stream, process_rows, process_cols,
+      m, n,
       tile_size, grid_mapping, full_matrices, rank_map, a, singular_values,
       work, /*u=*/nullptr, &vh_buffer, /*compute_u=*/false,
       /*compute_vh=*/true, status, collective_params, collective_cliques);
@@ -905,7 +908,7 @@ absl::Status XlaCusolverMpGesvdVhDispatch(
 
 // Executes values-only GESVD without allocating singular-vector outputs.
 absl::Status XlaCusolverMpGesvdValuesDispatch(
-    se::Stream* stream, se::Stream* comm_stream, cudaStream_t cuda_stream,
+    se::Stream* stream, cudaStream_t cuda_stream,
     int64_t process_rows, int64_t process_cols, int64_t m, int64_t n,
     int64_t tile_size, int64_t grid_mapping, int64_t full_matrices,
     absl::Span<const int64_t> rank_map, ffi::AnyBuffer a,
@@ -915,7 +918,8 @@ absl::Status XlaCusolverMpGesvdValuesDispatch(
     const CollectiveParams* collective_params,
     const CollectiveCliques* collective_cliques) {
   return RunCusolverMpGesvdDispatch(
-      stream, comm_stream, cuda_stream, process_rows, process_cols, m, n,
+      stream, /*comm_stream=*/nullptr, cuda_stream, process_rows, process_cols,
+      m, n,
       tile_size, grid_mapping, full_matrices, rank_map, a, singular_values,
       work, /*u=*/nullptr, /*vh=*/nullptr, /*compute_u=*/false,
       /*compute_vh=*/false, status, collective_params, collective_cliques);

--- a/src/cuda/cusolvermp_routines/cusolvermp_lu_solve.cc
+++ b/src/cuda/cusolvermp_routines/cusolvermp_lu_solve.cc
@@ -577,7 +577,7 @@ absl::Status XlaCusolverMpLuSolvePrepare(
 // preserves the factorized storage required for input/output aliasing; the
 // solved input is reverse-redistributed and restored for JAX.
 absl::Status XlaCusolverMpLuSolveDispatch(
-    se::Stream* stream, se::Stream* comm_stream, cudaStream_t cuda_stream,
+    se::Stream* stream, cudaStream_t cuda_stream,
     se::OwningScratchAllocator<> scratch, int64_t process_rows,
     int64_t process_cols, int64_t n, int64_t nrhs,
     int64_t b_distribution_cols, int64_t tile_size, int64_t grid_mapping,
@@ -586,6 +586,9 @@ absl::Status XlaCusolverMpLuSolveDispatch(
     ffi::Result<ffi::BufferR1<S32>> status,
     const CollectiveParams* collective_params,
     const CollectiveCliques* collective_cliques) {
+  // Raw NCCL runs on the main compute stream
+  se::Stream* comm_stream = nullptr;
+
   // Stage 1: validate the local FFI buffers.  Python has already padded A/B to
   // the user-visible storage capacity needed by the requested process grid and
   // tile size; native code only checks the local contracts it will dereference.

--- a/src/cuda/cusolvermp_routines/cusolvermp_potrs.cc
+++ b/src/cuda/cusolvermp_routines/cusolvermp_potrs.cc
@@ -829,7 +829,7 @@ absl::Status XlaCusolverMpPotrsDispatchImpl(
 // Standard POTRS entry point. It avoids the diagonal reduction and NCCL scalar
 // collective used by the log-determinant path.
 absl::Status XlaCusolverMpPotrsDispatch(
-    se::Stream* stream, se::Stream* comm_stream, cudaStream_t cuda_stream,
+    se::Stream* stream, cudaStream_t cuda_stream,
     int64_t process_rows, int64_t process_cols, int64_t n, int64_t nrhs,
     int64_t b_distribution_cols, int64_t tile_size, int64_t grid_mapping,
     absl::Span<const int64_t> rank_map, ffi::AnyBuffer a, ffi::AnyBuffer b,
@@ -838,7 +838,8 @@ absl::Status XlaCusolverMpPotrsDispatch(
     const CollectiveParams* collective_params,
     const CollectiveCliques* collective_cliques) {
   return XlaCusolverMpPotrsDispatchImpl(
-      stream, comm_stream, cuda_stream, process_rows, process_cols, n, nrhs,
+      stream, /*comm_stream=*/nullptr, cuda_stream, process_rows, process_cols,
+      n, nrhs,
       b_distribution_cols, tile_size, grid_mapping, rank_map, a, b, a_work,
       b_out, status, /*logdet=*/nullptr, collective_params,
       collective_cliques);
@@ -848,7 +849,7 @@ absl::Status XlaCusolverMpPotrsDispatch(
 // the standard aliases while the additional replicated scalar is computed
 // directly from the distributed Cholesky factor.
 absl::Status XlaCusolverMpPotrsLogdetDispatch(
-    se::Stream* stream, se::Stream* comm_stream, cudaStream_t cuda_stream,
+    se::Stream* stream, cudaStream_t cuda_stream,
     int64_t process_rows, int64_t process_cols, int64_t n, int64_t nrhs,
     int64_t b_distribution_cols, int64_t tile_size, int64_t grid_mapping,
     absl::Span<const int64_t> rank_map, ffi::AnyBuffer a, ffi::AnyBuffer b,
@@ -858,7 +859,8 @@ absl::Status XlaCusolverMpPotrsLogdetDispatch(
     const CollectiveParams* collective_params,
     const CollectiveCliques* collective_cliques) {
   return XlaCusolverMpPotrsDispatchImpl(
-      stream, comm_stream, cuda_stream, process_rows, process_cols, n, nrhs,
+      stream, /*comm_stream=*/nullptr, cuda_stream, process_rows, process_cols,
+      n, nrhs,
       b_distribution_cols, tile_size, grid_mapping, rank_map, a, b, a_work,
       b_out, status, &logdet, collective_params, collective_cliques);
 }

--- a/src/cuda/cusolvermp_routines/cusolvermp_routines.h
+++ b/src/cuda/cusolvermp_routines/cusolvermp_routines.h
@@ -36,7 +36,7 @@ absl::Status XlaCusolverMpPotrsPrepare(
 // cuSOLVERMp POTRF/POTRS, reverse redistribution, and output layout restore in
 // one FFI dispatch.
 absl::Status XlaCusolverMpPotrsDispatch(
-    se::Stream* stream, se::Stream* comm_stream, cudaStream_t cuda_stream,
+    se::Stream* stream, cudaStream_t cuda_stream,
     int64_t process_rows, int64_t process_cols, int64_t n, int64_t nrhs,
     int64_t b_distribution_cols, int64_t tile_size, int64_t grid_mapping,
     absl::Span<const int64_t> rank_map, ffi::AnyBuffer a, ffi::AnyBuffer b,
@@ -49,7 +49,7 @@ absl::Status XlaCusolverMpPotrsDispatch(
 // returns the replicated real Cholesky log determinant in the matrix's real
 // component precision.
 absl::Status XlaCusolverMpPotrsLogdetDispatch(
-    se::Stream* stream, se::Stream* comm_stream, cudaStream_t cuda_stream,
+    se::Stream* stream, cudaStream_t cuda_stream,
     int64_t process_rows, int64_t process_cols, int64_t n, int64_t nrhs,
     int64_t b_distribution_cols, int64_t tile_size, int64_t grid_mapping,
     absl::Span<const int64_t> rank_map, ffi::AnyBuffer a, ffi::AnyBuffer b,
@@ -69,7 +69,7 @@ absl::Status XlaCusolverMpLuSolvePrepare(
 // cuSOLVERMp GETRF/GETRS, reverse redistribution, and output layout restore in
 // one FFI dispatch.
 absl::Status XlaCusolverMpLuSolveDispatch(
-    se::Stream* stream, se::Stream* comm_stream, cudaStream_t cuda_stream,
+    se::Stream* stream, cudaStream_t cuda_stream,
     se::OwningScratchAllocator<> scratch, int64_t process_rows,
     int64_t process_cols, int64_t n, int64_t nrhs,
     int64_t b_distribution_cols, int64_t tile_size, int64_t grid_mapping,
@@ -89,7 +89,7 @@ absl::Status XlaCusolverMpSyevdPrepare(
 // vector-producing cuSOLVERMp SYEVD, reverse eigenvector redistribution, and
 // output layout restore in one FFI dispatch.
 absl::Status XlaCusolverMpSyevdDispatch(
-    se::Stream* stream, se::Stream* comm_stream, cudaStream_t cuda_stream,
+    se::Stream* stream, cudaStream_t cuda_stream,
     int64_t process_rows, int64_t process_cols, int64_t n, int64_t tile_size,
     int64_t grid_mapping, absl::Span<const int64_t> rank_map, ffi::AnyBuffer a,
     ffi::Result<ffi::AnyBuffer> eigenvalues,
@@ -102,7 +102,7 @@ absl::Status XlaCusolverMpSyevdDispatch(
 // and cuSOLVERMp setup with vector-producing SYEVD, but omits the eigenvector
 // output and its reverse redistribution.
 absl::Status XlaCusolverMpSyevdValuesDispatch(
-    se::Stream* stream, se::Stream* comm_stream, cudaStream_t cuda_stream,
+    se::Stream* stream, cudaStream_t cuda_stream,
     int64_t process_rows, int64_t process_cols, int64_t n, int64_t tile_size,
     int64_t grid_mapping, absl::Span<const int64_t> rank_map, ffi::AnyBuffer a,
     ffi::Result<ffi::AnyBuffer> eigenvalues,
@@ -121,7 +121,7 @@ absl::Status XlaCusolverMpGesvdPrepare(
 // The four public dispatches select distinct FFI result lists so unrequested
 // matrix-sized outputs are never allocated by XLA.
 absl::Status XlaCusolverMpGesvdUvDispatch(
-    se::Stream* stream, se::Stream* comm_stream, cudaStream_t cuda_stream,
+    se::Stream* stream, cudaStream_t cuda_stream,
     int64_t process_rows, int64_t process_cols, int64_t m, int64_t n,
     int64_t tile_size, int64_t grid_mapping, int64_t full_matrices,
     absl::Span<const int64_t> rank_map, ffi::AnyBuffer a,
@@ -134,7 +134,7 @@ absl::Status XlaCusolverMpGesvdUvDispatch(
 
 // Runtime GESVD hook for singular values and left singular vectors.
 absl::Status XlaCusolverMpGesvdUDispatch(
-    se::Stream* stream, se::Stream* comm_stream, cudaStream_t cuda_stream,
+    se::Stream* stream, cudaStream_t cuda_stream,
     int64_t process_rows, int64_t process_cols, int64_t m, int64_t n,
     int64_t tile_size, int64_t grid_mapping, int64_t full_matrices,
     absl::Span<const int64_t> rank_map, ffi::AnyBuffer a,
@@ -146,7 +146,7 @@ absl::Status XlaCusolverMpGesvdUDispatch(
 
 // Runtime GESVD hook for singular values and right singular vectors.
 absl::Status XlaCusolverMpGesvdVhDispatch(
-    se::Stream* stream, se::Stream* comm_stream, cudaStream_t cuda_stream,
+    se::Stream* stream, cudaStream_t cuda_stream,
     int64_t process_rows, int64_t process_cols, int64_t m, int64_t n,
     int64_t tile_size, int64_t grid_mapping, int64_t full_matrices,
     absl::Span<const int64_t> rank_map, ffi::AnyBuffer a,
@@ -159,7 +159,7 @@ absl::Status XlaCusolverMpGesvdVhDispatch(
 // Runtime values-only GESVD hook. It omits both singular-vector outputs and
 // ends after the distributed factorization has produced the singular values.
 absl::Status XlaCusolverMpGesvdValuesDispatch(
-    se::Stream* stream, se::Stream* comm_stream, cudaStream_t cuda_stream,
+    se::Stream* stream, cudaStream_t cuda_stream,
     int64_t process_rows, int64_t process_cols, int64_t m, int64_t n,
     int64_t tile_size, int64_t grid_mapping, int64_t full_matrices,
     absl::Span<const int64_t> rank_map, ffi::AnyBuffer a,

--- a/src/cuda/cusolvermp_routines/cusolvermp_syevd.cc
+++ b/src/cuda/cusolvermp_routines/cusolvermp_syevd.cc
@@ -749,7 +749,7 @@ absl::Status RunCusolverMpSyevdDispatch(
 // The overwritten matrix work buffer remains distinct from the eigenvector
 // output required by the cuSOLVERMp API.
 absl::Status XlaCusolverMpSyevdDispatch(
-    se::Stream* stream, se::Stream* comm_stream, cudaStream_t cuda_stream,
+    se::Stream* stream, cudaStream_t cuda_stream,
     int64_t process_rows, int64_t process_cols, int64_t n, int64_t tile_size,
     int64_t grid_mapping, absl::Span<const int64_t> rank_map, ffi::AnyBuffer a,
     ffi::Result<ffi::AnyBuffer> eigenvalues,
@@ -759,7 +759,8 @@ absl::Status XlaCusolverMpSyevdDispatch(
     const CollectiveCliques* collective_cliques) {
   ffi::AnyBuffer vector_buffer = *vectors;
   return RunCusolverMpSyevdDispatch(
-      stream, comm_stream, cuda_stream, process_rows, process_cols, n,
+      stream, /*comm_stream=*/nullptr, cuda_stream, process_rows, process_cols,
+      n,
       tile_size, grid_mapping, rank_map, a, eigenvalues, work, &vector_buffer,
       /*compute_eigenvectors=*/true, status, collective_params,
       collective_cliques);
@@ -768,7 +769,7 @@ absl::Status XlaCusolverMpSyevdDispatch(
 // Executes eigenvalues-only SYEVD without allocating or restoring a
 // matrix-sized eigenvector output.
 absl::Status XlaCusolverMpSyevdValuesDispatch(
-    se::Stream* stream, se::Stream* comm_stream, cudaStream_t cuda_stream,
+    se::Stream* stream, cudaStream_t cuda_stream,
     int64_t process_rows, int64_t process_cols, int64_t n, int64_t tile_size,
     int64_t grid_mapping, absl::Span<const int64_t> rank_map, ffi::AnyBuffer a,
     ffi::Result<ffi::AnyBuffer> eigenvalues,
@@ -777,7 +778,8 @@ absl::Status XlaCusolverMpSyevdValuesDispatch(
     const CollectiveParams* collective_params,
     const CollectiveCliques* collective_cliques) {
   return RunCusolverMpSyevdDispatch(
-      stream, comm_stream, cuda_stream, process_rows, process_cols, n,
+      stream, /*comm_stream=*/nullptr, cuda_stream, process_rows, process_cols,
+      n,
       tile_size, grid_mapping, rank_map, a, eigenvalues, work,
       /*vectors=*/nullptr, /*compute_eigenvectors=*/false, status,
       collective_params, collective_cliques);

--- a/src/cuda/memory_redist/block_cyclic_2d.cc
+++ b/src/cuda/memory_redist/block_cyclic_2d.cc
@@ -655,7 +655,10 @@ absl::Status ExecutePadded2DNativePlanRawImpl(
     se::DeviceAddressBase scratch_base, int64_t scratch_elements,
     const CollectiveParams* collective_params,
     const CollectiveCliques* collective_cliques) {
-  if (stream == nullptr || comm_stream == nullptr || cuda_stream == nullptr) {
+  // `comm_stream` is optional: XLA only supplies a communication stream when
+  // the surrounding module allocates one, so ChooseNcclStream falls back to the
+  // main compute stream when it is null.
+  if (stream == nullptr || cuda_stream == nullptr) {
     return absl::InvalidArgumentError(
         absl::StrFormat("%s requires XLA and CUDA stream contexts", caller));
   }

--- a/src/cuda/xla_ffi/handlers.cc
+++ b/src/cuda/xla_ffi/handlers.cc
@@ -27,6 +27,19 @@
 //   4. XLA calls the execute symbol at runtime with streams, buffers,
 //      attributes, scratch allocators, and collective contexts.
 //
+// The execute bindings deliberately do NOT request
+// `ffi::CommunicationStream<N>`. That indexes `CollectiveParams::async_streams`,
+// whose size XLA derives from the async-collective thunks present in the
+// surrounding module. These handlers are synchronous and emit none, so the pool
+// is empty and the binding fails to decode. Through jax 0.11.0 a compatibility
+// floor in `GetNumAdditionalStreams()` allocated the legacy pool for every
+// executable, which is the only reason index 1 used to resolve; jax 0.11.1
+// removed it, and XLA offers no way for a custom call to request one. The raw
+// NCCL work therefore runs on the main compute stream: `ChooseNcclStream` in
+// runtime.cc returns `uses_comm_stream=false` for a null `comm_stream`, and the
+// cross-stream `WaitFor` pairs it guards are unnecessary there because ordering
+// on a single stream is implicit.
+//
 #include "runtime.h"
 #include "../cusolvermp_routines/cusolvermp_routines.h"
 
@@ -54,7 +67,6 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
     XlaCusolverMpPotrsFFI, XlaCusolverMpPotrsDispatch,
     ffi::Ffi::Bind()
         .Ctx<ffi::Stream>()
-        .Ctx<ffi::CommunicationStream<1>>()
         .Ctx<ffi::PlatformStream<cudaStream_t>>()
         .Attr<int64_t>("process_rows")
         .Attr<int64_t>("process_cols")
@@ -88,7 +100,6 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
     XlaCusolverMpPotrsLogdetFFI, XlaCusolverMpPotrsLogdetDispatch,
     ffi::Ffi::Bind()
         .Ctx<ffi::Stream>()
-        .Ctx<ffi::CommunicationStream<1>>()
         .Ctx<ffi::PlatformStream<cudaStream_t>>()
         .Attr<int64_t>("process_rows")
         .Attr<int64_t>("process_cols")
@@ -121,7 +132,6 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
     XlaCusolverMpLuSolveFFI, XlaCusolverMpLuSolveDispatch,
     ffi::Ffi::Bind()
         .Ctx<ffi::Stream>()
-        .Ctx<ffi::CommunicationStream<1>>()
         .Ctx<ffi::PlatformStream<cudaStream_t>>()
         .Ctx<ffi::ScratchAllocator>()
         .Attr<int64_t>("process_rows")
@@ -154,7 +164,6 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
     XlaCusolverMpSyevdFFI, XlaCusolverMpSyevdDispatch,
     ffi::Ffi::Bind()
         .Ctx<ffi::Stream>()
-        .Ctx<ffi::CommunicationStream<1>>()
         .Ctx<ffi::PlatformStream<cudaStream_t>>()
         .Attr<int64_t>("process_rows")
         .Attr<int64_t>("process_cols")
@@ -176,7 +185,6 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
     XlaCusolverMpSyevdValuesFFI, XlaCusolverMpSyevdValuesDispatch,
     ffi::Ffi::Bind()
         .Ctx<ffi::Stream>()
-        .Ctx<ffi::CommunicationStream<1>>()
         .Ctx<ffi::PlatformStream<cudaStream_t>>()
         .Attr<int64_t>("process_rows")
         .Attr<int64_t>("process_cols")
@@ -203,7 +211,6 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
     XlaCusolverMpGesvdUvFFI, XlaCusolverMpGesvdUvDispatch,
     ffi::Ffi::Bind()
         .Ctx<ffi::Stream>()
-        .Ctx<ffi::CommunicationStream<1>>()
         .Ctx<ffi::PlatformStream<cudaStream_t>>()
         .Attr<int64_t>("process_rows")
         .Attr<int64_t>("process_cols")
@@ -227,7 +234,6 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
     XlaCusolverMpGesvdUFFI, XlaCusolverMpGesvdUDispatch,
     ffi::Ffi::Bind()
         .Ctx<ffi::Stream>()
-        .Ctx<ffi::CommunicationStream<1>>()
         .Ctx<ffi::PlatformStream<cudaStream_t>>()
         .Attr<int64_t>("process_rows")
         .Attr<int64_t>("process_cols")
@@ -250,7 +256,6 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
     XlaCusolverMpGesvdVhFFI, XlaCusolverMpGesvdVhDispatch,
     ffi::Ffi::Bind()
         .Ctx<ffi::Stream>()
-        .Ctx<ffi::CommunicationStream<1>>()
         .Ctx<ffi::PlatformStream<cudaStream_t>>()
         .Attr<int64_t>("process_rows")
         .Attr<int64_t>("process_cols")
@@ -274,7 +279,6 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
     XlaCusolverMpGesvdValuesFFI, XlaCusolverMpGesvdValuesDispatch,
     ffi::Ffi::Bind()
         .Ctx<ffi::Stream>()
-        .Ctx<ffi::CommunicationStream<1>>()
         .Ctx<ffi::PlatformStream<cudaStream_t>>()
         .Attr<int64_t>("process_rows")
         .Attr<int64_t>("process_cols")


### PR DESCRIPTION
Add support for JAX 0.11.x. This will require bumping to Python >= 3.12 and changes to the XLA communicator. 

In trying to do this I encountered some very specific bugs. I was hoping we could get away with compiling once for all JAX 0.11.x versions, however, there is an XLA API change between 0.11.0 and 0.11.1 that breaks JAXMg right now, see See #31.

I will try to implement the fix suggested in #31 and see if that results in stable results across 0.11.0 and 0.11.1.


