### PR TITLE
Bump cuSOLVERMp to 0.9.1

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -52,10 +52,10 @@ jobs:
         include:
           - cuda_major: '12'
             cuda_archs: sm_70,sm_80,sm_90,sm_120,compute_90
-            cusolvermp: nvidia-cusolvermp-cu12==0.9.0.6427
+            cusolvermp: nvidia-cusolvermp-cu12==0.9.1.9318.post1
           - cuda_major: '13'
             cuda_archs: sm_80,sm_90,sm_120,compute_90
-            cusolvermp: nvidia-cusolvermp-cu13==0.9.0.6427
+            cusolvermp: nvidia-cusolvermp-cu13==0.9.1.9318.post1
     steps:
       - name: Checkout jaxmg
         uses: actions/checkout@v4

--- a/docs/install.md
+++ b/docs/install.md
@@ -35,7 +35,7 @@ NVIDIA GPU families are:
 | CUDA 12 | V100, A100, H100/H200, and Blackwell GPUs |
 | CUDA 13 | A100, H100/H200, and Blackwell GPUs |
 
-The binaries use JAX `0.10.1` and cuSOLVERMp `0.9.0.6427`. See
+The binaries use JAX `0.10.1` and cuSOLVERMp `0.9.1.9318.post1`. See
 [Building from source](technical_details/building_from_source.md) for the native
 build procedure.
 

--- a/docs/technical_details/building_from_source.md
+++ b/docs/technical_details/building_from_source.md
@@ -101,7 +101,7 @@ Choose the values for the backend:
 
 ```bash
 CUDA_MAJOR=12
-CUSOLVERMP_PACKAGE=nvidia-cusolvermp-cu12==0.9.0.6427
+CUSOLVERMP_PACKAGE=nvidia-cusolvermp-cu12==0.9.1.9318.post1
 CAPABILITIES=sm_70,sm_80,sm_90,sm_120,compute_90
 ```
 
@@ -126,7 +126,7 @@ For CUDA 13, use:
 
 ```bash
 CUDA_MAJOR=13
-CUSOLVERMP_PACKAGE=nvidia-cusolvermp-cu13==0.9.0.6427
+CUSOLVERMP_PACKAGE=nvidia-cusolvermp-cu13==0.9.1.9318.post1
 CAPABILITIES=sm_80,sm_90,sm_120,compute_90
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ docs = [
 dev = [
     "matplotlib>=3.10.3",
     "jax[cuda12]==0.10.1",
-    "nvidia-cusolvermp-cu12==0.9.0.6427",
+    "nvidia-cusolvermp-cu12==0.9.1.9318.post1",
     "pytest==8.2.1",
     "mkdocs==1.6.1",
     "mkdocs-material==9.6.23",
@@ -73,20 +73,20 @@ dev = [
 
 cuda12 = [
     "jax[cuda12]==0.10.1",
-    "nvidia-cusolvermp-cu12==0.9.0.6427",
+    "nvidia-cusolvermp-cu12==0.9.1.9318.post1",
 ]
 
 cuda13 = [
     "jax[cuda13]==0.10.1",
-    "nvidia-cusolvermp-cu13==0.9.0.6427",
+    "nvidia-cusolvermp-cu13==0.9.1.9318.post1",
 ]
 
 cuda12-local = [
     "jax[cuda12-local]==0.10.1",
-    "nvidia-cusolvermp-cu12==0.9.0.6427",
+    "nvidia-cusolvermp-cu12==0.9.1.9318.post1",
 ]
 
 cuda13-local = [
     "jax[cuda13-local]==0.10.1",
-    "nvidia-cusolvermp-cu13==0.9.0.6427",
+    "nvidia-cusolvermp-cu13==0.9.1.9318.post1",
 ]


### PR DESCRIPTION
## Summary

- update to cuSOLVERMp `0.9.1.9318.post1`

## Motivation

cuSOLVERMp 0.9.1 fixes large-problem failures and silently incorrect singular or eigenvectors in `cusolverMpGesvd` and `cusolverMpSyevd`. It also reduces workspace requirements for the eigenvalue and singular-value routines.

NVIDIA release notes: https://docs.nvidia.com/cuda/cusolvermp/release_notes/index.html
