### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,14 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+type: software
+title: "JAXMg: A multi-GPU linear solver in JAX"
+authors:
+  - family-names: "Tutt"
+    given-names: "Jacob Lewis"
+    orcid: "https://orcid.org/0009-0002-5358-4292"
+  - family-names: "Wiersema"
+    given-names: "Roeland"
+    orcid: "https://orcid.org/0000-0002-0839-4265"
+repository-code: "https://github.com/flatironinstitute/jaxmg"
+license: "Apache-2.0"
+version: "1.1.1"


### PR DESCRIPTION
JOSS reviewers ask for a `CITATION.cff`, and this repository does not have one yet.

Generated from the author list in `jaxmg/paper/paper.md`: 2 author(s), with given and family names taken from each author's ORCID record rather than split from the display name, because compound surnames do not split reliably.

`license` is `Apache-2.0`, read from the LICENSE file. `version` is `1.1.1`, the newest release tag. 

Verified with `cffconvert --validate`: valid against schema 1.2.0.